### PR TITLE
Rebrand checks for the .desktop file and the snapcraft config.

### DIFF
--- a/electrum-nmc
+++ b/electrum-nmc
@@ -28,7 +28,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 is_bundle = getattr(sys, 'frozen', False)
-is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "electrum.desktop"))
+is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "electrum-nmc.desktop"))
 is_android = 'ANDROID_DATA' in os.environ
 
 # move this back to gui/kivy/__init.py once plugins are moved

--- a/gui/qt/__init__.py
+++ b/gui/qt/__init__.py
@@ -98,7 +98,7 @@ class ElectrumGui:
         if hasattr(QtCore.Qt, "AA_ShareOpenGLContexts"):
             QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
         if hasattr(QGuiApplication, 'setDesktopFileName'):
-            QGuiApplication.setDesktopFileName('electrum.desktop')
+            QGuiApplication.setDesktopFileName('electrum-nmc.desktop')
         self.config = config
         self.daemon = daemon
         self.plugins = plugins

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,23 +1,23 @@
-name: electrum
+name: electrum-nmc
 version: master
-summary: Bitcoin thin client
+summary: Namecoin thin client
 description: |
-  Lightweight Bitcoin client
+  Lightweight Namecoin client
 
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
 
 apps:
-  electrum:
-    command: desktop-launch electrum
+  electrum-nmc:
+    command: desktop-launch electrum-nmc
     plugs: [network, network-bind, x11, unity7]
 
 parts:
-  electrum:
+  electrum-nmc:
     source: .
     plugin: python
     python-version: python3
     stage-packages: [python3-pyqt5]
     build-packages: [pyqt5-dev-tools]
-    install: pyrcc5 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python3.5/site-packages/electrum_gui/qt/icons_rc.py
+    install: pyrcc5 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python3.5/site-packages/electrum_nmc_gui/qt/icons_rc.py
     after: [desktop-qt5]


### PR DESCRIPTION
This should fix the ability to run Electrum-NMC locally (i.e. without pip3 install).