### PR TITLE
Namecoin / AuxPoW: Fix Namecoin module name in auxpow branch.

### DIFF
--- a/lib/auxpow.py
+++ b/lib/auxpow.py
@@ -45,9 +45,9 @@
 
 import binascii
 
-# electrum_nmc.blockchain is an absolute import because cyclic imports must be
+# electrum.blockchain is an absolute import because cyclic imports must be
 # absolute prior to Python 3.5.
-import electrum_nmc.blockchain
+import electrum.blockchain
 from .bitcoin import hash_encode, hash_decode
 from .crypto import Hash
 from . import transaction


### PR DESCRIPTION
This should fix a Travis fail.  Note that this change needs to be manually reverted when the auxpow branch is merged into the Namecoin master branch.