### PR TITLE
Namecoin: Rebrand macOS package name.

### DIFF
--- a/contrib/build-osx/make_osx
+++ b/contrib/build-osx/make_osx
@@ -3,7 +3,7 @@
 # Parameterize
 PYTHON_VERSION=3.6.4
 BUILDDIR=/tmp/electrum-nmc-build
-PACKAGE=Electrum
+PACKAGE=Electrum-NMC
 GIT_REPO=https://github.com/namecoin/electrum-nmc
 LIBSECP_VERSION=452d8e4d2a2f9f1b5be6b02e18f1ba102e5ca0b4
 


### PR DESCRIPTION
This should fix the Travis fail on macOS.

TODO:

- [x] Test this.