### PR TITLE
Fix accidental Namecoin module name in auxpow branch.  (3.2.2 Backport)

### DIFF
--- a/lib/auxpow.py
+++ b/lib/auxpow.py
@@ -45,9 +45,9 @@
 
 import binascii
 
-# electrum_nmc.blockchain is an absolute import because cyclic imports must be
+# electrum.blockchain is an absolute import because cyclic imports must be
 # absolute prior to Python 3.5.
-import electrum_nmc.blockchain
+import electrum.blockchain
 from .bitcoin import hash_encode, hash_decode
 from .crypto import Hash
 from . import transaction


### PR DESCRIPTION
Backport #17 to 3.2.2 branch.