### PR TITLE
Fix broadcast() usage

### DIFF
--- a/electrum_nmc/commands.py
+++ b/electrum_nmc/commands.py
@@ -681,9 +681,10 @@ class Commands:
         new_rand = new_result["rand"]
         new_tx = new_result["tx"]["hex"]
 
-        status, msg = self.broadcast(new_tx)
-        if not status:
-            raise Exception("Error broadcasting name pre-registration: " + msg)
+        try:
+            self.broadcast(new_tx)
+        except Exception as e:
+            raise Exception("Error broadcasting name pre-registration: " + str(e))
 
         # We add the name_new transaction to the wallet explicitly because
         # otherwise, the wallet will only learn about the name_new once the
@@ -931,9 +932,10 @@ class Commands:
 
             if current_depth >= trigger_depth:
                 tx = queue_item["tx"]
-                status, msg = self.broadcast(tx)
-                if not status:
-                    errors[txid] = msg
+                try:
+                    self.broadcast(tx)
+                except Exception as e:
+                    errors[txid] = str(e)
 
                 to_unqueue.append(txid)
 

--- a/electrum_nmc/gui/qt/configure_name_dialog.py
+++ b/electrum_nmc/gui/qt/configure_name_dialog.py
@@ -149,10 +149,11 @@ class ConfigureNameDialog(QDialog):
         # TODO: support non-ASCII encodings
         tx = name_update(identifier.decode('ascii'), value.decode('ascii'), recipient_address)['hex']
 
-        status, msg = broadcast(tx)
-        if not status:
+        try:
+            broadcast(tx)
+        except Exception as e:
             formatted_name = format_name_identifier(identifier)
-            self.main_window.show_error(_("Error broadcasting update for ") + formatted_name + ": " + str(msg))
+            self.main_window.show_error(_("Error broadcasting update for ") + formatted_name + ": " + str(e))
             return
 
         # As far as I can tell, we don't need to explicitly add the transaction

--- a/electrum_nmc/gui/qt/uno_list.py
+++ b/electrum_nmc/gui/qt/uno_list.py
@@ -127,10 +127,11 @@ class UNOList(UTXOList):
                 # The name was recently updated, so skip it and don't renew.
                 continue
 
-            status, msg = broadcast(tx)
-            if not status:
+            try:
+                broadcast(tx)
+            except Exception as e:
                 formatted_name = format_name_identifier(identifier)
-                self.parent.show_error(_("Error broadcasting renewal for ") + formatted_name + ": " + str(msg))
+                self.parent.show_error(_("Error broadcasting renewal for ") + formatted_name + ": " + str(e))
                 continue
 
             # We add the transaction to the wallet explicitly because


### PR DESCRIPTION
Upstream Electrum changed the return value of broadcast().  Previously,
errors would be encoded in the return value.  Now errors are raised as
exceptions, and the return value is just a txid.  This commit fixes our
usage accordingly.