### PR TITLE
Rebrand Docker image/container names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ jobs:
       services:
         - docker
       install:
-        - sudo docker build --no-cache -t electrum-wine-builder-img ./contrib/build-wine/
+        - sudo docker build --no-cache -t electrum-nmc-wine-builder-img ./contrib/build-wine/
       script:
-        - sudo docker run --name electrum-wine-builder-cont -v $PWD:/opt/wine64/drive_c/electrum-nmc --rm --workdir /opt/wine64/drive_c/electrum-nmc/contrib/build-wine electrum-wine-builder-img ./build.sh
+        - sudo docker run --name electrum-nmc-wine-builder-cont -v $PWD:/opt/wine64/drive_c/electrum-nmc --rm --workdir /opt/wine64/drive_c/electrum-nmc/contrib/build-wine electrum-nmc-wine-builder-img ./build.sh
       after_success: true
     - name: "Android build"
       language: python
@@ -53,12 +53,12 @@ jobs:
       install:
         - pip install requests && ./contrib/make_locale
         - ./contrib/make_packages
-        - sudo docker build --no-cache -t electrum-android-builder-img electrum_nmc/gui/kivy/tools
+        - sudo docker build --no-cache -t electrum-nmc-android-builder-img electrum_nmc/gui/kivy/tools
       script:
         - sudo chown -R 1000:1000 .
         # Output something every minute or Travis kills the job
         - while sleep 60; do echo "=====[ $SECONDS seconds still running ]====="; done &
-        - sudo docker run -it -u 1000:1000 --rm --name electrum-android-builder-cont -v $PWD:/home/user/wspace/electrum --workdir /home/user/wspace/electrum electrum-android-builder-img ./contrib/make_apk
+        - sudo docker run -it -u 1000:1000 --rm --name electrum-nmc-android-builder-cont -v $PWD:/home/user/wspace/electrum --workdir /home/user/wspace/electrum electrum-nmc-android-builder-img ./contrib/make_apk
         # kill background sleep loop
         - kill %1
         - ls -la bin
@@ -82,9 +82,9 @@ jobs:
       services:
         - docker
       install:
-        - sudo docker build --no-cache -t electrum-appimage-builder-img ./contrib/build-linux/appimage/
+        - sudo docker build --no-cache -t electrum-nmc-appimage-builder-img ./contrib/build-linux/appimage/
       script:
-        - sudo docker run --name electrum-appimage-builder-cont -v $PWD:/opt/electrum-nmc --rm --workdir /opt/electrum-nmc/contrib/build-linux/appimage electrum-appimage-builder-img ./build.sh
+        - sudo docker run --name electrum-nmc-appimage-builder-cont -v $PWD:/opt/electrum-nmc --rm --workdir /opt/electrum-nmc/contrib/build-linux/appimage electrum-nmc-appimage-builder-img ./build.sh
       after_success: true
     - stage: release check
       install:

--- a/contrib/build-linux/appimage/README.md
+++ b/contrib/build-linux/appimage/README.md
@@ -17,18 +17,18 @@ folder.
 2. Build image
 
     ```
-    $ sudo docker build --no-cache -t electrum-appimage-builder-img contrib/build-linux/appimage
+    $ sudo docker build --no-cache -t electrum-nmc-appimage-builder-img contrib/build-linux/appimage
     ```
 
 3. Build binary
 
     ```
     $ sudo docker run -it \
-        --name electrum-appimage-builder-cont \
+        --name electrum-nmc-appimage-builder-cont \
         -v $PWD:/opt/electrum-nmc \
         --rm \
         --workdir /opt/electrum-nmc/contrib/build-linux/appimage \
-        electrum-appimage-builder-img \
+        electrum-nmc-appimage-builder-img \
         ./build.sh
     ```
 

--- a/electrum_nmc/gui/kivy/Readme.md
+++ b/electrum_nmc/gui/kivy/Readme.md
@@ -21,7 +21,7 @@ folder.
 2. Build image
 
     ```
-    $ sudo docker build -t electrum-android-builder-img electrum_nmc/gui/kivy/tools
+    $ sudo docker build -t electrum-nmc-android-builder-img electrum_nmc/gui/kivy/tools
     ```
 
 3. Build locale files
@@ -40,11 +40,11 @@ folder.
 
     ```
     $ sudo docker run -it --rm \
-        --name electrum-android-builder-cont \
+        --name electrum-nmc-android-builder-cont \
         -v $PWD:/home/user/wspace/electrum \
         -v ~/.keystore:/home/user/.keystore \
         --workdir /home/user/wspace/electrum \
-        electrum-android-builder-img \
+        electrum-nmc-android-builder-img \
         ./contrib/make_apk
     ```
     This mounts the project dir inside the container,
@@ -74,7 +74,7 @@ $ adb shell monkey -p org.namecoin.electrum_nmc.electrum_nmc 1
 $ sudo docker run -it --rm \
     -v $PWD:/home/user/wspace/electrum \
     --workdir /home/user/wspace/electrum \
-    electrum-android-builder-img
+    electrum-nmc-android-builder-img
 ```
 
 


### PR DESCRIPTION
This should help avoid name collisions if Electrum and Electrum-NMC are built on the same machine.