### PR TITLE
Fix crash in seed dialog caused by incomplete import aliasing

### DIFF
--- a/electrum_nmc/gui/qt/seed_dialog.py
+++ b/electrum_nmc/gui/qt/seed_dialog.py
@@ -150,7 +150,7 @@ class SeedLayout(QVBoxLayout):
 
     def initialize_completer(self):
         english_list = Mnemonic('en').wordlist
-        old_list = electrum_nmc.old_mnemonic.words
+        old_list = electrum.old_mnemonic.words
         self.wordlist = english_list + list(set(old_list) - set(english_list)) #concat both lists
         self.wordlist.sort()
         self.completer = QCompleter(self.wordlist)


### PR DESCRIPTION
The crash occurs during the wallet creation wizard.