### PR TITLE
Rebrand locale paths in make_tgz

### DIFF
--- a/contrib/make_tgz
+++ b/contrib/make_tgz
@@ -22,10 +22,10 @@ git submodule update --init
         exit 1
     fi
     for i in ./locale/*; do
-        dir="$ROOT_FOLDER"/electrum/$i/LC_MESSAGES
+        dir="$ROOT_FOLDER"/electrum_nmc/electrum/$i/LC_MESSAGES
         mkdir -p $dir
         msgfmt --output-file=$dir/electrum.mo $i/electrum.po || true
-        cp $i/electrum.po "$ROOT_FOLDER"/electrum/$i/electrum.po
+        cp $i/electrum.po "$ROOT_FOLDER"/electrum_nmc/electrum/$i/electrum.po
     done
 )
 


### PR DESCRIPTION
Upstream Electrum recently added locale installation to `make_tgz`; the paths from upstream aren't correct for Namecoin.  This PR fixes those paths.