### PR TITLE
Fix UNOList for non-empty wallet with empty blockchain

### DIFF
--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -99,7 +99,10 @@ class UNOList(UTXOList):
             height = x.get('height')
             header_at_tip = self.network.blockchain().header_at_tip()
             #chain_height = self.network.blockchain().height()
-            expires_in, expires_datetime = name_expiration_datetime_estimate(height, header_at_tip['block_height'], header_at_tip['timestamp'])
+            if header_at_tip is not None:
+                expires_in, expires_datetime = name_expiration_datetime_estimate(height, header_at_tip['block_height'], header_at_tip['timestamp'])
+            else:
+                expires_in, expires_datetime = None, None
             status = '' if expires_in is not None else _('Update Pending')
 
         if 'name' in name_op:


### PR DESCRIPTION
UNOList was trying to access data from `header_at_tip` without checking if it was `None` first.  The result was that if a wallet that owns a name is opened in an Electrum-NMC instance that has an empty blockchain, Electrum-NMC would crash on startup.  This PR fixes the issue by checking for `None` before trying to use `header_at_tip`.