### PR TITLE
Fix arguments for name wallet commands

### DIFF
--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -689,7 +689,7 @@ class Commands:
         return tx.as_dict()
 
     @command('wp')
-    async def name_new(self, identifier, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_existing=False):
+    async def name_new(self, identifier, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, from_coins=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_existing=False):
         """Create a name_new transaction. """
         if not allow_existing:
             name_exists = True
@@ -701,7 +701,8 @@ class Commands:
                 raise NameAlreadyExistsError("The name is already registered")
 
         tx_fee = satoshis(fee)
-        domain = from_addr.split(',') if from_addr else None
+        domain_addr = from_addr.split(',') if from_addr else None
+        domain_coins = from_coins.split(',') if from_coins else None
 
         # TODO: support non-ASCII encodings
         # TODO: enforce length limit on identifier
@@ -713,7 +714,8 @@ class Commands:
                         fee=tx_fee,
                         feerate=feerate,
                         change_addr=change_addr,
-                        domain_addr=domain,
+                        domain_addr=domain_addr,
+                        domain_coins=domain_coins,
                         nocheck=nocheck,
                         unsigned=unsigned,
                         rbf=rbf,
@@ -723,7 +725,7 @@ class Commands:
         return {"tx": tx.as_dict(), "txid": tx.txid(), "rand": bh2u(rand)}
 
     @command('wp')
-    async def name_firstupdate(self, identifier, rand, name_new_txid, value, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_early=False):
+    async def name_firstupdate(self, identifier, rand, name_new_txid, value, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, from_coins=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_early=False):
         """Create a name_firstupdate transaction. """
         if not allow_early:
             conf = self.wallet.get_tx_height(name_new_txid).conf
@@ -732,7 +734,8 @@ class Commands:
                 raise NamePreRegistrationPendingError("The name pre-registration is still pending; wait " + str(remaining_conf) + "more blocks")
 
         tx_fee = satoshis(fee)
-        domain = from_addr.split(',') if from_addr else None
+        domain_addr = from_addr.split(',') if from_addr else None
+        domain_coins = from_coins.split(',') if from_coins else None
 
         # TODO: support non-ASCII encodings
         # TODO: enforce length limits on identifier and value
@@ -747,7 +750,8 @@ class Commands:
                         fee=tx_fee,
                         feerate=feerate,
                         change_addr=change_addr,
-                        domain_addr=domain,
+                        domain_addr=domain_addr,
+                        domain_coins=domain_coins,
                         nocheck=nocheck,
                         unsigned=unsigned,
                         rbf=rbf,
@@ -758,11 +762,12 @@ class Commands:
         return tx.as_dict()
 
     @command('wpn')
-    async def name_update(self, identifier, value=None, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None):
+    async def name_update(self, identifier, value=None, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, from_coins=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None):
         """Create a name_update transaction. """
 
         tx_fee = satoshis(fee)
-        domain = from_addr.split(',') if from_addr else None
+        domain_addr = from_addr.split(',') if from_addr else None
+        domain_coins = from_coins.split(',') if from_coins else None
 
         # Allow renewing a name without any value changes by omitting the
         # value.
@@ -793,7 +798,8 @@ class Commands:
                         fee=tx_fee,
                         feerate=feerate,
                         change_addr=change_addr,
-                        domain_addr=domain,
+                        domain_addr=domain_addr,
+                        domain_coins=domain_coins,
                         nocheck=nocheck,
                         unsigned=unsigned,
                         rbf=rbf,
@@ -804,7 +810,7 @@ class Commands:
         return tx.as_dict()
 
     @command('wpn')
-    async def name_autoregister(self, identifier, value, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, rbf=None, password=None, locktime=None, allow_existing=False):
+    async def name_autoregister(self, identifier, value, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, from_coins=None, change_addr=None, nocheck=False, rbf=None, password=None, locktime=None, allow_existing=False):
         """Creates a name_new transaction, broadcasts it, creates a corresponding name_firstupdate transaction, and queues it. """
 
         # Validate the value before we try to pre-register the name.  That way,
@@ -818,6 +824,7 @@ class Commands:
                                    fee=fee,
                                    feerate=feerate,
                                    from_addr=from_addr,
+                                   from_coins=from_coins,
                                    change_addr=change_addr,
                                    nocheck=nocheck,
                                    rbf=rbf,

--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -839,8 +839,6 @@ class Commands:
         new_rand = new_result["rand"]
         new_tx = new_result["tx"]["hex"]
 
-        self.broadcast(new_tx)
-
         # We add the name_new transaction to the wallet explicitly because
         # otherwise, the wallet will only learn about the name_new once the
         # ElectrumX server sends us a copy of the transaction, which is several
@@ -855,25 +853,30 @@ class Commands:
                 new_addr = o.address
                 break
 
-        firstupdate_result = self.name_firstupdate(identifier,
-                                                   new_rand,
-                                                   new_txid,
-                                                   value,
-                                                   destination=destination,
-                                                   amount=amount,
-                                                   fee=fee,
-                                                   feerate=feerate,
-                                                   from_addr=new_addr,
-                                                   change_addr=change_addr,
-                                                   nocheck=nocheck,
-                                                   rbf=rbf,
-                                                   password=password,
-                                                   locktime=locktime,
-                                                   allow_early=True,
-                                                   wallet=wallet)
-        firstupdate_tx = firstupdate_result["hex"]
+        try:
+            firstupdate_result = self.name_firstupdate(identifier,
+                                                       new_rand,
+                                                       new_txid,
+                                                       value,
+                                                       destination=destination,
+                                                       amount=amount,
+                                                       fee=fee,
+                                                       feerate=feerate,
+                                                       from_addr=new_addr,
+                                                       change_addr=change_addr,
+                                                       nocheck=nocheck,
+                                                       rbf=rbf,
+                                                       password=password,
+                                                       locktime=locktime,
+                                                       allow_early=True,
+                                                       wallet=wallet)
+            firstupdate_tx = firstupdate_result["hex"]
+            self.queuetransaction(firstupdate_tx, 12, trigger_txid=new_txid)
+        except Exception as e:
+            self.removelocaltx(new_txid, wallet=wallet)
+            raise e
 
-        self.queuetransaction(firstupdate_tx, 12, trigger_txid=new_txid)
+        self.broadcast(new_tx)
 
     @command('w')
     async def onchain_history(self, year=None, show_addresses=False, show_fiat=False, wallet: Abstract_Wallet = None):

--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -689,7 +689,7 @@ class Commands:
         return tx.as_dict()
 
     @command('wp')
-    async def name_new(self, identifier, destination=None, amount=0.0, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_existing=False):
+    async def name_new(self, identifier, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_existing=False):
         """Create a name_new transaction. """
         if not allow_existing:
             name_exists = True
@@ -711,6 +711,7 @@ class Commands:
 
         tx = self._mktx([],
                         fee=tx_fee,
+                        feerate=feerate,
                         change_addr=change_addr,
                         domain_addr=domain,
                         nocheck=nocheck,
@@ -722,7 +723,7 @@ class Commands:
         return {"tx": tx.as_dict(), "txid": tx.txid(), "rand": bh2u(rand)}
 
     @command('wp')
-    async def name_firstupdate(self, identifier, rand, name_new_txid, value, destination=None, amount=0.0, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_early=False):
+    async def name_firstupdate(self, identifier, rand, name_new_txid, value, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, allow_early=False):
         """Create a name_firstupdate transaction. """
         if not allow_early:
             conf = self.wallet.get_tx_height(name_new_txid).conf
@@ -744,6 +745,7 @@ class Commands:
 
         tx = self._mktx([],
                         fee=tx_fee,
+                        feerate=feerate,
                         change_addr=change_addr,
                         domain_addr=domain,
                         nocheck=nocheck,
@@ -756,7 +758,7 @@ class Commands:
         return tx.as_dict()
 
     @command('wpn')
-    async def name_update(self, identifier, value=None, destination=None, amount=0.0, fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None):
+    async def name_update(self, identifier, value=None, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False, rbf=None, password=None, locktime=None):
         """Create a name_update transaction. """
 
         tx_fee = satoshis(fee)
@@ -789,6 +791,7 @@ class Commands:
 
         tx = self._mktx([],
                         fee=tx_fee,
+                        feerate=feerate,
                         change_addr=change_addr,
                         domain_addr=domain,
                         nocheck=nocheck,
@@ -801,7 +804,7 @@ class Commands:
         return tx.as_dict()
 
     @command('wpn')
-    async def name_autoregister(self, identifier, value, destination=None, amount=0.0, fee=None, from_addr=None, change_addr=None, nocheck=False, rbf=None, password=None, locktime=None, allow_existing=False):
+    async def name_autoregister(self, identifier, value, destination=None, amount=0.0, fee=None, feerate=None, from_addr=None, change_addr=None, nocheck=False, rbf=None, password=None, locktime=None, allow_existing=False):
         """Creates a name_new transaction, broadcasts it, creates a corresponding name_firstupdate transaction, and queues it. """
 
         # Validate the value before we try to pre-register the name.  That way,
@@ -813,6 +816,7 @@ class Commands:
         new_result = self.name_new(identifier,
                                    amount=amount+0.005,
                                    fee=fee,
+                                   feerate=feerate,
                                    from_addr=from_addr,
                                    change_addr=change_addr,
                                    nocheck=nocheck,
@@ -847,6 +851,7 @@ class Commands:
                                                    destination=destination,
                                                    amount=amount,
                                                    fee=fee,
+                                                   feerate=feerate,
                                                    from_addr=new_addr,
                                                    change_addr=change_addr,
                                                    nocheck=nocheck,

--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -709,7 +709,16 @@ class Commands:
         name_op, rand = build_name_new(identifier_bytes)
         memo = "Pre-Registration: " + format_name_identifier(identifier_bytes)
 
-        tx = self._mktx([], tx_fee, change_addr, domain, nocheck, unsigned, rbf, password, locktime, name_outputs=[(destination, amount, name_op, memo)])
+        tx = self._mktx([],
+                        fee=tx_fee,
+                        change_addr=change_addr,
+                        domain_addr=domain,
+                        nocheck=nocheck,
+                        unsigned=unsigned,
+                        rbf=rbf,
+                        password=password,
+                        locktime=locktime,
+                        name_outputs=[(destination, amount, name_op, memo)])
         return {"tx": tx.as_dict(), "txid": tx.txid(), "rand": bh2u(rand)}
 
     @command('wp')
@@ -733,7 +742,17 @@ class Commands:
         name_op = {"op": OP_NAME_FIRSTUPDATE, "name": identifier_bytes, "rand": rand_bytes, "value": value_bytes}
         memo = "Registration: " + format_name_identifier(identifier_bytes)
 
-        tx = self._mktx([], tx_fee, change_addr, domain, nocheck, unsigned, rbf, password, locktime, name_input_txids=[name_new_txid], name_outputs=[(destination, amount, name_op, memo)])
+        tx = self._mktx([],
+                        fee=tx_fee,
+                        change_addr=change_addr,
+                        domain_addr=domain,
+                        nocheck=nocheck,
+                        unsigned=unsigned,
+                        rbf=rbf,
+                        password=password,
+                        locktime=locktime,
+                        name_input_txids=[name_new_txid],
+                        name_outputs=[(destination, amount, name_op, memo)])
         return tx.as_dict()
 
     @command('wpn')
@@ -768,7 +787,17 @@ class Commands:
         name_op = {"op": OP_NAME_UPDATE, "name": identifier_bytes, "value": value_bytes}
         memo = ("Renew: " if renew else "Update: ") + format_name_identifier(identifier_bytes)
 
-        tx = self._mktx([], tx_fee, change_addr, domain, nocheck, unsigned, rbf, password, locktime, name_input_identifiers=[identifier_bytes], name_outputs=[(destination, amount, name_op, memo)])
+        tx = self._mktx([],
+                        fee=tx_fee,
+                        change_addr=change_addr,
+                        domain_addr=domain,
+                        nocheck=nocheck,
+                        unsigned=unsigned,
+                        rbf=rbf,
+                        password=password,
+                        locktime=locktime,
+                        name_input_identifiers=[identifier_bytes],
+                        name_outputs=[(destination, amount, name_op, memo)])
         return tx.as_dict()
 
     @command('wpn')
@@ -781,7 +810,16 @@ class Commands:
         validate_value_length(value)
 
         # TODO: Don't hardcode the 0.005 name_firstupdate fee
-        new_result = self.name_new(identifier, amount=amount+0.005, fee=fee, from_addr=from_addr, change_addr=change_addr, nocheck=nocheck, rbf=rbf, password=password, locktime=locktime, allow_existing=allow_existing)
+        new_result = self.name_new(identifier,
+                                   amount=amount+0.005,
+                                   fee=fee,
+                                   from_addr=from_addr,
+                                   change_addr=change_addr,
+                                   nocheck=nocheck,
+                                   rbf=rbf,
+                                   password=password,
+                                   locktime=locktime,
+                                   allow_existing=allow_existing)
         new_txid = new_result["txid"]
         new_rand = new_result["rand"]
         new_tx = new_result["tx"]["hex"]
@@ -802,7 +840,20 @@ class Commands:
                 new_addr = o.address
                 break
 
-        firstupdate_result = self.name_firstupdate(identifier, new_rand, new_txid, value, destination=destination, amount=amount, fee=fee, from_addr=new_addr, change_addr=change_addr, nocheck=nocheck, rbf=rbf, password=password, locktime=locktime, allow_early=True)
+        firstupdate_result = self.name_firstupdate(identifier,
+                                                   new_rand,
+                                                   new_txid,
+                                                   value,
+                                                   destination=destination,
+                                                   amount=amount,
+                                                   fee=fee,
+                                                   from_addr=new_addr,
+                                                   change_addr=change_addr,
+                                                   nocheck=nocheck,
+                                                   rbf=rbf,
+                                                   password=password,
+                                                   locktime=locktime,
+                                                   allow_early=True)
         firstupdate_tx = firstupdate_result["hex"]
 
         self.queuetransaction(firstupdate_tx, 12, trigger_txid=new_txid)


### PR DESCRIPTION
Upstream has changed the arguments for wallet commands; this PR updates the name wallet commands to match.