### PR TITLE
Fix bytes/hex mismatch in get_utxos

### DIFF
--- a/electrum_nmc/electrum/address_synchronizer.py
+++ b/electrum_nmc/electrum/address_synchronizer.py
@@ -836,7 +836,7 @@ class AddressSynchronizer(Logger):
                 if only_uno_txids is not None:
                     if utxo.name_op is None:
                         continue
-                    if utxo.prevout.txid not in only_uno_txids:
+                    if utxo.prevout.txid.hex() not in only_uno_txids:
                         continue
                 if only_uno_identifiers is not None:
                     if utxo.name_op is None:


### PR DESCRIPTION
This was causing `name_autoregister` to erroneously report "insufficient funds" at the `name_firstupdate` step.