### PR TITLE
Allow zero-output coinbase transactions in auxpow

### DIFF
--- a/electrum/auxpow.py
+++ b/electrum/auxpow.py
@@ -115,6 +115,7 @@ def deserialize_auxpow_header(base_header, s, start_position=0) -> (dict, int):
     # The parent coinbase transaction is first.
     # Deserialize it and save the trailing data.
     parent_coinbase_tx = Transaction(s, expect_trailing_data=True, copy_input=False, start_position=start_position)
+    parent_coinbase_tx._allow_zero_outputs = True
     start_position = fast_tx_deserialize(parent_coinbase_tx)
     auxpow_header['parent_coinbase_tx'] = parent_coinbase_tx
 

--- a/electrum/tests/test_auxpow.py
+++ b/electrum/tests/test_auxpow.py
@@ -15,6 +15,14 @@ namecoin_header_37174 = '01010100d681bfa4acb5e0dc772a0099ce069ae4841ee2292ba731a
 namecoin_prev_hash_37174 = '8adc6de6bd46c73aa631a72b29e21e84e49a06ce99002a77dce0b5aca4bf81d6'
 namecoin_target_37174 = 0x242a4a0000000000000000000000000000000000000000000000
 
+# This is a header with auxpow whose parent block coinbase tx has no outputs.
+# Even though that coinbase tx would not be valid as a transaction, this is
+# valid as part of an auxpow.
+# It is testnet block 233'281 (5ca6bad276325045620eb532b4008bd4220d8d6a8384ac9b1b655fcf85649acb).
+header_zero_output_auxpow = '04010100917ef486bdc93073ae0cb87fcb099055458376bd40ffca2c960451f17fbc43ac69f594e5808d30c0e4c7fd4546596b77abb56cf03612355c3a2ed01419fae7e17d508a5effff0f1d0000000001000000010000000000000000000000000000000000000000000000000000000000000000ffffffff29285ca6bad276325045620eb532b4008bd4220d8d6a8384ac9b1b655fcf85649acb0100000000000000ffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000dcdf08e5d7361bfdc6e62ce08265fb5d7680a65e4bfc7cdf52e9638f57b2d4e4000000000000000094a40000'
+prev_hash_zero_output_auxpow = 'ac43bc7ff15104962ccaff40bd768345559009cb7fb80cae7330c9bd86f47e91'
+target_zero_output_auxpow = blockchain.Blockchain.bits_to_target(0x1d0fffff)
+
 class Test_auxpow(SequentialTestCase):
 
     @staticmethod
@@ -123,6 +131,11 @@ class Test_auxpow(SequentialTestCase):
     def test_verify_auxpow_header_implicit_coinbase(self):
         header = self.deserialize_with_auxpow(namecoin_header_19414)
         blockchain.Blockchain.verify_header(header, namecoin_prev_hash_19414, namecoin_target_19414)
+
+    # Verify a header whose auxpow has a coinbase transaction without outputs.
+    def test_verify_auxpow_header_zero_output_coinbase(self):
+        header = self.deserialize_with_auxpow(header_zero_output_auxpow)
+        blockchain.Blockchain.verify_header(header, prev_hash_zero_output_auxpow, target_zero_output_auxpow)
 
     # Check that a non-generate AuxPoW transaction is rejected.
     # Equivalent to shouldRejectNonGenerateAuxPoW in libdohj tests.

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -538,6 +538,10 @@ class Transaction:
 
         self._cached_txid = None  # type: Optional[str]
 
+        # When parsing the parent coinbase tx of an auxpow, we have to allow
+        # there not being any outputs (which is normally not valid).
+        self._allow_zero_outputs = False
+
     @property
     def locktime(self):
         return self._locktime
@@ -607,7 +611,7 @@ class Transaction:
             raise SerializationError('tx needs to have at least 1 input')
         self._inputs = [parse_input(vds) for i in range(n_vin)]
         n_vout = vds.read_compact_size()
-        if n_vout < 1:
+        if n_vout < 1 and not self._allow_zero_outputs:
             raise SerializationError('tx needs to have at least 1 output')
         self._outputs = [parse_output(vds) for i in range(n_vout)]
         if is_segwit:


### PR DESCRIPTION
Even though a transaction without outputs is not valid, it can be *deserialised* fine by Namecoin Core and thus is accepted as parent coinbase in an auxpow.  Electrum-NMC's deserialiser already fails on that, and thus Electrum-NMC did so far not accept those auxpow's (leading to a consensus failure with Namecoin Core).

With this patch, we allow auxpow's whose parent coinbase transaction has no outputs, so that Electrum-NMC follows the behaviour of Namecoin Core.

Note that auxpow's like that are very unlikely to occur on mainnet, as a miner would essentially have to build a Namecoin-only block for it, giving up the merge-mining bitcoin reward (and thus it is very costly to do so).  But it is nevertheless a possibility.  On testnet, there are actual blocks that failed to sync with Electrum-NMC before this patch (e.g. the one from the new unit test).