### PR TITLE
Fix some constants in tests

### DIFF
--- a/electrum_nmc/electrum/tests/address_conversion.py
+++ b/electrum_nmc/electrum/tests/address_conversion.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Electrum-NMC - lightweight Namecoin client
-# Copyright (C) 2019 Namecoin Developers
+# Copyright (C) 2019-2020 Namecoin Developers
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -62,6 +62,10 @@ def frombtc(inp: str) -> str:
     if inp[:3].lower() == "tb1":
         return convert_bech32(inp, BitcoinTestnet.SEGWIT_HRP)
 
+    # Handle bech32 lightning addresses.
+    if inp[:4].lower() == "lnbc":
+        return convert_ln_bech32(inp, BitcoinMainnet.SEGWIT_HRP)
+
     # Otherwise, try to base58-decode it and then look at the version to
     # determine what it could have been.
     try:
@@ -96,4 +100,15 @@ def convert_bech32(inp: str, new_hrp: str) -> str:
     if data is None:
         raise AssertionError(f"Invalid bech32 for conversion: {inp}")
 
+    return segwit_addr.bech32_encode(new_hrp, data)
+
+
+def convert_ln_bech32(inp: str, new_base_hrp: str) -> str:
+    """Converts a Lightning address in bech32 format to another base HRP"""
+
+    old_hrp, data = segwit_addr.bech32_decode(inp, ignore_long_length=True)
+    if data is None:
+        raise AssertionError(f"Invalid bech32 for conversion: {inp}")
+
+    new_hrp = "ln" + new_base_hrp + old_hrp[4:]
     return segwit_addr.bech32_encode(new_hrp, data)

--- a/electrum_nmc/electrum/tests/test_bitcoin.py
+++ b/electrum_nmc/electrum/tests/test_bitcoin.py
@@ -181,9 +181,13 @@ class Test_bitcoin(ElectrumTestCase):
         sig1_b64 = base64.b64encode(sig1)
         sig2_b64 = base64.b64encode(sig2)
 
-        # Re-signed these with Namecoin Core, since the upstream Electrum ones are invalid for Namecoin's msg_magic.
-        self.assertEqual(sig1_b64, b'IKqxjcFykcFJPUsIJtUvR5901nJnD/WN326bDVHqnvxjX6+E/mXH9FY+MNpNyl/liXQDhd53BihaVH2lOGknzFU=')
-        self.assertEqual(sig2_b64, b'HMBdVzZJfSqhGsrJ6NgUoLUxPmTS0NSxA2Y/q3Te69MVNtt4aWbJORq+0MCllDfqiKo9IIaWpSmXk0VXlaIMxx4=')
+        # Due to a difference in low-r signing, Namecoin Core and Electrum-NMC
+        # produce different signatures.  The values here are produced by
+        # Electrum-NMC but have been checked to verify with Namecoin Core.
+        # The difference in signing behaviour was introduced in
+        # https://github.com/spesmilo/electrum/pull/5820.
+        self.assertEqual(sig1_b64, b'H0u4fB+LyaNuPCdJMihq2MQR1H9yRJC2cUKKqo6gAUWGLARkz43rLY7QNKbJWq5eoBN+mK8ZD7hFuEzAXYpHFUk=')
+        self.assertEqual(sig2_b64, b'GygNVRsJ28/zwXdPDk59BjZkRvjpZFkoBtzkGfSWOGqFZ8CT863QFBxbU6xVbJUkyHbcI5uHW2Z782O5DcGaKKI=')
 
         self.assertTrue(ecc.verify_message_with_address(addr1, sig1, msg1))
         self.assertTrue(ecc.verify_message_with_address(addr2, sig2, msg2))

--- a/electrum_nmc/electrum/tests/test_bolt11.py
+++ b/electrum_nmc/electrum/tests/test_bolt11.py
@@ -124,14 +124,14 @@ class TestBolt11(ElectrumTestCase):
         self.assertEqual(150, lndecode(invoice).get_min_final_cltv_expiry())
 
     def test_features(self):
-        lnaddr = lndecode("lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9qzsze992adudgku8p05pstl6zh7av6rx2f297pv89gu5q93a0hf3g7lynl3xq56t23dpvah6u7y9qey9lccrdml3gaqwc6nxsl5ktzm464sq73t7cl")
+        lnaddr = lndecode(frombtc("lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9qzsze992adudgku8p05pstl6zh7av6rx2f297pv89gu5q93a0hf3g7lynl3xq56t23dpvah6u7y9qey9lccrdml3gaqwc6nxsl5ktzm464sq73t7cl"))
         self.assertEqual(514, lnaddr.get_tag('9'))
 
         with self.assertRaises(UnknownEvenFeatureBits):
-            lndecode("lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9q4pqqqqqqqqqqqqqqqqqqszk3ed62snp73037h4py4gry05eltlp0uezm2w9ajnerhmxzhzhsu40g9mgyx5v3ad4aqwkmvyftzk4k9zenz90mhjcy9hcevc7r3lx2sphzfxz7")
+            lndecode(frombtc("lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9q4pqqqqqqqqqqqqqqqqqqszk3ed62snp73037h4py4gry05eltlp0uezm2w9ajnerhmxzhzhsu40g9mgyx5v3ad4aqwkmvyftzk4k9zenz90mhjcy9hcevc7r3lx2sphzfxz7"))
 
     def test_payment_secret(self):
-        lnaddr = lndecode("lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsdq5vdhkven9v5sxyetpdees9q5sqqqqqqqqqqqqqqqpqsqvvh7ut50r00p3pg34ea68k7zfw64f8yx9jcdk35lh5ft8qdr8g4r0xzsdcrmcy9hex8un8d8yraewvhqc9l0sh8l0e0yvmtxde2z0hgpzsje5l")
+        lnaddr = lndecode(frombtc("lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsdq5vdhkven9v5sxyetpdees9q5sqqqqqqqqqqqqqqqpqsqvvh7ut50r00p3pg34ea68k7zfw64f8yx9jcdk35lh5ft8qdr8g4r0xzsdcrmcy9hex8un8d8yraewvhqc9l0sh8l0e0yvmtxde2z0hgpzsje5l"))
         self.assertEqual((1 << 9) + (1 << 15) + (1 << 99), lnaddr.get_tag('9'))
         self.assertEqual(b"\x11" * 32, lnaddr.payment_secret)
 


### PR DESCRIPTION
This fixes some constants in tests to make them pass for Namecoin.  In particular, we update the expected signatures in `test_bitcoin.py` (the new values have been checked to verify fine with Namecoin Core), and rebrand some Lightning invoices in `test_bolt11.py`.

This reduces the number of test failures from six to three.