### PR TITLE
Hide 0.01 NMC in name outputs from GUI

### DIFF
--- a/electrum_nmc/electrum/gui/kivy/main_window.py
+++ b/electrum_nmc/electrum/gui/kivy/main_window.py
@@ -917,7 +917,7 @@ class ElectrumWindow(App):
             self.show_error(str(e))
             send_exception_to_crash_reporter(e)
             return ''
-        amount = tx.output_value()
+        amount = tx.output_value_display()
         __, x_fee_amount = run_hook('get_tx_extra_fee', self.wallet, tx) or (None, 0)
         amount_after_all_fees = amount - x_fee_amount
         return format_satoshis_plain(amount_after_all_fees, self.decimal_point())

--- a/electrum_nmc/electrum/gui/kivy/uix/dialogs/__init__.py
+++ b/electrum_nmc/electrum/gui/kivy/uix/dialogs/__init__.py
@@ -212,7 +212,7 @@ class OutputList(RecycleView):
     def update(self, outputs: Sequence['TxOutput']):
         res = []
         for o in outputs:
-            value = self.app.format_amount_and_units(o.value)
+            value = self.app.format_amount_and_units(o.value_display)
             res.append({'address': o.get_ui_address_str(), 'value': value})
         self.data = res
 

--- a/electrum_nmc/electrum/gui/kivy/uix/screens.py
+++ b/electrum_nmc/electrum/gui/kivy/uix/screens.py
@@ -348,7 +348,7 @@ class SendScreen(CScreen):
     def _do_pay_onchain(self, invoice, rbf):
         # make unsigned transaction
         outputs = invoice['outputs']  # type: List[PartialTxOutput]
-        amount = sum(map(lambda x: x.value, outputs))
+        amount = sum(map(lambda x: x.value_display, outputs))
         coins = self.app.wallet.get_spendable_coins(None)
         try:
             tx = self.app.wallet.make_unsigned_transaction(coins=coins, outputs=outputs)
@@ -362,10 +362,14 @@ class SendScreen(CScreen):
         if rbf:
             tx.set_rbf(True)
         fee = tx.get_fee()
+        fee_display = tx.get_fee_display()
+        name_fee = None if (fee is None or fee_display is None) else (fee_display - fee)
         msg = [
             _("Amount to be sent") + ": " + self.app.format_amount_and_units(amount),
             _("Mining fee") + ": " + self.app.format_amount_and_units(fee),
         ]
+        if name_fee is not None and name_fee != 0:
+            msg.append(_("Name registration fee") + ": " + self.app.format_amount_and_units(name_fee))
         x_fee = run_hook('get_tx_extra_fee', self.app.wallet, tx)
         if x_fee:
             x_fee_address, x_fee_amount = x_fee

--- a/electrum_nmc/electrum/gui/qt/channels_list.py
+++ b/electrum_nmc/electrum/gui/qt/channels_list.py
@@ -292,7 +292,7 @@ class ChannelsList(MyTreeView):
                 amount_e.setFrozen(False)
                 self.main_window.show_error(str(e))
                 return
-            amount = tx.output_value()
+            amount = tx.output_value_display()
             amount = min(amount, LN_MAX_FUNDING_SAT)
             amount_e.setAmount(amount)
         max_button = EnterButton(_("Max"), spend_max)

--- a/electrum_nmc/electrum/gui/qt/confirm_tx_dialog.py
+++ b/electrum_nmc/electrum/gui/qt/confirm_tx_dialog.py
@@ -131,24 +131,31 @@ class ConfirmTxDialog(TxEditor, WindowModalDialog):
         grid.addWidget(HelpLabel(_("Mining fee") + ": ", msg), 1, 0)
         grid.addWidget(self.fee_label, 1, 1)
 
+        self.name_fee_label = QLabel(_("Name registration fee") + ": ")
+        self.name_fee_label.setVisible(False)
+        self.name_fee_value = QLabel('')
+        self.name_fee_value.setVisible(False)
+        grid.addWidget(self.name_fee_label, 2, 0)
+        grid.addWidget(self.name_fee_value, 2, 1)
+
         self.extra_fee_label = QLabel(_("Additional fees") + ": ")
         self.extra_fee_label.setVisible(False)
         self.extra_fee_value = QLabel('')
         self.extra_fee_value.setVisible(False)
-        grid.addWidget(self.extra_fee_label, 2, 0)
-        grid.addWidget(self.extra_fee_value, 2, 1)
+        grid.addWidget(self.extra_fee_label, 2+1, 0)
+        grid.addWidget(self.extra_fee_value, 2+1, 1)
 
         self.fee_slider = FeeSlider(self, self.config, self.fee_slider_callback)
-        grid.addWidget(self.fee_slider, 5, 1)
+        grid.addWidget(self.fee_slider, 5+1, 1)
 
         self.message_label = QLabel(self.default_message())
-        grid.addWidget(self.message_label, 6, 0, 1, -1)
+        grid.addWidget(self.message_label, 6+1, 0, 1, -1)
         self.pw_label = QLabel(_('Password'))
         self.pw_label.setVisible(self.password_required)
         self.pw = PasswordLineEdit()
         self.pw.setVisible(self.password_required)
-        grid.addWidget(self.pw_label, 8, 0)
-        grid.addWidget(self.pw, 8, 1, 1, -1)
+        grid.addWidget(self.pw_label, 8+1, 0)
+        grid.addWidget(self.pw, 8+1, 1, 1, -1)
         self.preview_button = QPushButton(_('Advanced'))
         self.preview_button.clicked.connect(self.on_preview)
         grid.addWidget(self.preview_button, 0, 2)
@@ -199,7 +206,7 @@ class ConfirmTxDialog(TxEditor, WindowModalDialog):
 
     def update(self):
         tx = self.tx
-        amount = tx.output_value() if self.output_value == '!' else self.output_value
+        amount = tx.output_value_display() if self.output_value == '!' else self.output_value
         self.amount_label.setText(self.main_window.format_amount_and_units(amount))
 
         if self.not_enough_funds:
@@ -216,7 +223,16 @@ class ConfirmTxDialog(TxEditor, WindowModalDialog):
             return
 
         fee = tx.get_fee()
+        fee_display = tx.get_fee_display()
+        name_fee = None if (fee is None or fee_display is None) else (fee_display - fee)
         self.fee_label.setText(self.main_window.format_amount_and_units(fee))
+        if name_fee is not None and name_fee != 0:
+            self.name_fee_label.setVisible(True)
+            self.name_fee_value.setVisible(True)
+            self.name_fee_value.setText(self.main_window.format_amount_and_units(name_fee))
+        else:
+            self.name_fee_label.setVisible(False)
+            self.name_fee_value.setVisible(False)
         x_fee = run_hook('get_tx_extra_fee', self.wallet, tx)
         if x_fee:
             x_fee_address, x_fee_amount = x_fee

--- a/electrum_nmc/electrum/gui/qt/main_window.py
+++ b/electrum_nmc/electrum/gui/qt/main_window.py
@@ -1379,7 +1379,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             return
 
         self.max_button.setChecked(True)
-        amount = tx.output_value()
+        amount = tx.output_value_display()
         __, x_fee_amount = run_hook('get_tx_extra_fee', self.wallet, tx) or (None, 0)
         amount_after_all_fees = amount - x_fee_amount
         self.amount_e.setAmount(amount_after_all_fees)
@@ -1415,7 +1415,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             if o.scriptpubkey is None:
                 self.show_error(_('Namecoin Address is None'))
                 return True
-            if o.value is None:
+            if o.value_display is None:
                 self.show_error(_('Invalid Amount'))
                 return True
 
@@ -1561,7 +1561,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             outputs=outputs,
             fee=fee_est,
             is_sweep=is_sweep)
-        output_values = [x.value for x in outputs]
+        output_values = [x.value_display for x in outputs]
         if output_values.count('!') > 1:
             self.show_error(_("More than one output set to spend max"))
             return
@@ -1958,7 +1958,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         grid.addWidget(QLabel(_("Requestor") + ':'), 0, 0)
         grid.addWidget(QLabel(pr.get_requestor()), 0, 1)
         grid.addWidget(QLabel(_("Amount") + ':'), 1, 0)
-        outputs_str = '\n'.join(map(lambda x: self.format_amount(x.value)+ self.base_unit() + ' @ ' + x.address, pr.get_outputs()))
+        outputs_str = '\n'.join(map(lambda x: self.format_amount(x.value_display)+ self.base_unit() + ' @ ' + x.address, pr.get_outputs()))
         grid.addWidget(QLabel(outputs_str), 1, 1)
         expires = pr.get_expiration_date()
         grid.addWidget(QLabel(_("Memo") + ':'), 2, 0)
@@ -2787,7 +2787,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.show_message(repr(e))
             return
         scriptpubkey = bfh(bitcoin.address_to_script(addr))
-        outputs = [PartialTxOutput(scriptpubkey=scriptpubkey, value='!')]
+        outputs = [PartialTxOutput(scriptpubkey=scriptpubkey, value='!', is_display=True)]
         self.warn_if_watching_only()
         self.pay_onchain_dialog(coins, outputs, external_keypairs=keypairs)
 

--- a/electrum_nmc/electrum/gui/qt/paytoedit.py
+++ b/electrum_nmc/electrum/gui/qt/paytoedit.py
@@ -96,7 +96,7 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit, Logger):
         x, y = line.split(',')
         scriptpubkey = self.parse_output(x)
         amount = self.parse_amount(y)
-        return PartialTxOutput(scriptpubkey=scriptpubkey, value=amount)
+        return PartialTxOutput(scriptpubkey=scriptpubkey, value=amount, is_display=True)
 
     def parse_output(self, x) -> bytes:
         try:
@@ -172,10 +172,10 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit, Logger):
                 self.errors.append(PayToLineError(idx=i, line_content=line.strip(), exc=e))
                 continue
             outputs.append(output)
-            if output.value == '!':
+            if output.value_display == '!':
                 is_max = True
             else:
-                total += output.value
+                total += output.value_display
         if outputs:
             self.win.set_onchain(True)
 
@@ -201,7 +201,7 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit, Logger):
                 amount = '!'
             else:
                 amount = self.amount_edit.get_amount()
-            self.outputs = [PartialTxOutput(scriptpubkey=self.payto_scriptpubkey, value=amount)]
+            self.outputs = [PartialTxOutput(scriptpubkey=self.payto_scriptpubkey, value=amount, is_display=True)]
 
         return self.outputs[:]
 

--- a/electrum_nmc/electrum/gui/qt/utxo_list.py
+++ b/electrum_nmc/electrum/gui/qt/utxo_list.py
@@ -85,7 +85,7 @@ class UTXOList(MyTreeView):
         if self._spend_set is not None:
             coins = [self._utxo_dict[x] for x in self._spend_set]
             coins = self._filter_frozen_coins(coins)
-            amount = sum(x.value_sats() for x in coins)
+            amount = sum(x.value_sats_display() for x in coins)
             amount_str = self.parent.format_amount_and_units(amount)
             num_outputs_str = _("{} outputs available ({} total)").format(len(coins), len(utxos))
             self.parent.set_coincontrol_msg(_("Coin control active") + f': {num_outputs_str}, {amount_str}')
@@ -99,7 +99,7 @@ class UTXOList(MyTreeView):
         name_short = utxo.prevout.txid.hex()[:16] + '...' + ":%d" % utxo.prevout.out_idx
         self._utxo_dict[name] = utxo
         label = self.wallet.get_label(utxo.prevout.txid.hex())
-        amount = self.parent.format_amount(utxo.value_sats(), whitespaces=True)
+        amount = self.parent.format_amount(utxo.value_sats_display(), whitespaces=True)
         labels = [name_short, address, label, amount, '%d'%height]
         utxo_item = [QStandardItem(x) for x in labels]
         self.set_editability(utxo_item)

--- a/electrum_nmc/electrum/transaction.py
+++ b/electrum_nmc/electrum/transaction.py
@@ -93,11 +93,13 @@ SIGHASH_ALL = 1
 
 class TxOutput:
     scriptpubkey: bytes
-    value: Union[int, str]
+    value: Union[int, str] # Includes the 0.01 NMC locked inside name coins.
 
-    def __init__(self, *, scriptpubkey: bytes, value: Union[int, str]):
+    def __init__(self, *, scriptpubkey: bytes, value: Union[int, str], is_display: bool = False):
         self.scriptpubkey = scriptpubkey
         self.value = value  # str when the output is set to max: '!'  # in satoshis
+        if is_display:
+            self.value_display = value
 
     @classmethod
     def from_address_and_value(cls, address: str, value: Union[int, str]) -> Union['TxOutput', 'PartialTxOutput']:
@@ -108,13 +110,14 @@ class TxOutput:
         if self.name_op is not None:
             raise Exception("TxOutput already has a name operation")
 
+        value_display = self.value_display
+
         # Serialize the name script, and prepend it to the scriptpubkey
         name_script = bfh(name_op_to_script(name_op))
         self.scriptpubkey = name_script + self.scriptpubkey
 
         # Name ops include an extra 0.01 NMC locked inside the output
-        if type(self.value) is int:
-            self.value += COIN // 100
+        self.value_display = value_display
 
     def serialize_to_network(self) -> bytes:
         buf = int.to_bytes(self.value, 8, byteorder="little", signed=False)
@@ -158,6 +161,32 @@ class TxOutput:
         if addr is not None:
             return addr
         return f"SCRIPT {self.scriptpubkey.hex()}"
+
+    @property
+    def value_display(self) -> Union[int, str]:
+        if isinstance(self.value, str):
+            return self.value
+
+        if self.name_op is None:
+            return self.value
+
+        # Name ops include an extra 0.01 NMC locked inside the output, which we
+        # hide here.
+        return self.value - COIN // 100
+
+    @value_display.setter
+    def value_display(self, value: Union[int, str]):
+        if isinstance(value, str):
+            self.value = value
+            return
+
+        if self.name_op is None:
+            self.value = value
+            return
+
+        # Name ops include an extra 0.01 NMC locked inside the output, which we
+        # add here.
+        self.value = value + COIN // 100
 
     def __repr__(self):
         return f"<TxOutput script={self.scriptpubkey.hex()} address={self.address} value={self.value}>"
@@ -513,8 +542,6 @@ def parse_output(vds: BCDataStream) -> TxOutput:
         raise SerializationError('invalid output amount (too large)')
     if value < 0:
         raise SerializationError('invalid output amount (negative)')
-    # TODO: Namecoin: Subtract the 0.01 NMC that's permanently locked in the
-    # name, raise error if the result is less than 0.
     scriptpubkey = vds.read_bytes(vds.read_compact_size())
     return TxOutput(value=value, scriptpubkey=scriptpubkey)
 
@@ -1340,6 +1367,14 @@ class PartialTxInput(TxInput, PSBTSection):
             return self.witness_utxo.value
         return None
 
+    def value_sats_display(self) -> Optional[int]:
+        if self.name_op is None:
+            return self.value_sats()
+
+        # Name ops include an extra 0.01 NMC locked inside the output, which we
+        # hide here.
+        return self.value_sats() - COIN // 100
+
     @property
     def address(self) -> Optional[str]:
         if self._trusted_address is not None:
@@ -1810,12 +1845,27 @@ class PartialTransaction(Transaction):
             raise MissingTxInputAmount()
         return sum(input_values)
 
+    def input_value_display(self) -> int:
+        input_values = [txin.value_sats_display() for txin in self.inputs()]
+        if any([val is None for val in input_values]):
+            raise MissingTxInputAmount()
+        return sum(input_values)
+
     def output_value(self) -> int:
         return sum(o.value for o in self.outputs())
+
+    def output_value_display(self) -> int:
+        return sum(o.value_display for o in self.outputs())
 
     def get_fee(self) -> Optional[int]:
         try:
             return self.input_value() - self.output_value()
+        except MissingTxInputAmount:
+            return None
+
+    def get_fee_display(self) -> Optional[int]:
+        try:
+            return self.input_value_display() - self.output_value_display()
         except MissingTxInputAmount:
             return None
 


### PR DESCRIPTION
This functionality was broken by merging the PSBT refactor from upstream.

Relevant strings that were grepped for in `/electrum_nmc/electrum/gui/`:

~~~
TxOutput(
PartialTxOutput(
.value
.value_sats
.input_value
.output_value
.get_fee
~~~
