### PR TITLE
Hide 0.01 NMC from name outputs in balance

### DIFF
--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -381,7 +381,12 @@ def get_queued_firstupdate_from_new(wallet, txid, idx):
     return None, None
 
 
-def get_wallet_name_delta(wallet, tx):
+def get_wallet_name_delta(wallet, tx, domain=None):
+    # get domain
+    if domain is None:
+        domain = wallet.get_addresses()
+    domain = set(domain)
+
     name_input_is_mine = False
     name_output_is_mine = False
 
@@ -391,12 +396,12 @@ def get_wallet_name_delta(wallet, tx):
     tx = PartialTransaction.from_tx(tx)
     for txin in tx.inputs():
         wallet.add_input_info(txin)
-        if txin.address is not None and wallet.is_mine(txin.address) and txin.name_op is not None:
+        if txin.address is not None and wallet.is_mine(txin.address) and txin.address in domain and txin.name_op is not None:
             name_input_is_mine = True
             if 'value' in txin.name_op:
                 name_input_value = txin.name_op['value']
     for o in tx.outputs():
-        if o.address is not None and wallet.is_mine(o.address) and o.name_op is not None:
+        if o.address is not None and wallet.is_mine(o.address) and txin.address in domain and o.name_op is not None:
             name_output_is_mine = True
             if 'value' in o.name_op:
                 name_output_value = o.name_op['value']


### PR DESCRIPTION
This functionality was broken by merging the PSBT refactor from upstream.

Fixes https://github.com/namecoin/electrum-nmc/issues/240