### PR TITLE
Add constant for name expiration.

### DIFF
--- a/electrum_nmc/electrum/blockchain.py
+++ b/electrum_nmc/electrum/blockchain.py
@@ -671,7 +671,7 @@ class Blockchain(Logger):
         # which will add some latency.  TODO: Allow user-configurable pre-
         # fetching of checkpointed unexpired chunks.
         #n = self.height() // 2016
-        n = (self.height() - 36000) // 2016
+        n = (self.height() - constants.net.NAME_EXPIRATION) // 2016
 
         for index in range(n):
             h = self.get_hash((index+1) * 2016 -1)

--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -848,7 +848,7 @@ class Commands:
             # name renewal with that malicious value.  expires_in is None when
             # the transaction has 0 confirmations.
             expires_in = list_results["expires_in"]
-            if expires_in is None or expires_in > 36000 - 12:
+            if expires_in is None or expires_in > constants.net.NAME_EXPIRATION - 12:
                 raise NameUpdatedTooRecentlyError("Name was updated too recently to safely determine current value.  Either wait or specify an explicit value.")
 
             value = list_results["value"]
@@ -1222,7 +1222,7 @@ class Commands:
                     current_height = await self.name_show(trigger_name)["height"]
                     current_depth = chain_height - current_height + 1
                 except NameNotFoundError:
-                    current_depth = 36000
+                    current_depth = constants.net.NAME_EXPIRATION
                 except Exception:
                     continue
 
@@ -1324,7 +1324,7 @@ class Commands:
         # just skip it and look for an older transaction.  If it has more than
         # 18 server confirmations but under 12 local confirmations, then we're
         # probably still syncing, and we error.
-        unexpired_height = max_chain_height - 35999
+        unexpired_height = max_chain_height - constants.net.NAME_EXPIRATION + 1
         unverified_height = local_chain_height - 12
         unmined_height = max_chain_height - 18
 

--- a/electrum_nmc/electrum/constants.py
+++ b/electrum_nmc/electrum/constants.py
@@ -101,6 +101,8 @@ class BitcoinMainnet(AbstractNet):
     AUXPOW_CHAIN_ID = 0x0001
     AUXPOW_START_HEIGHT = 19200
 
+    NAME_EXPIRATION = 36000
+
 
 class BitcoinTestnet(AbstractNet):
 
@@ -137,6 +139,8 @@ class BitcoinTestnet(AbstractNet):
     AUXPOW_CHAIN_ID = 0x0001
     AUXPOW_START_HEIGHT = 0
 
+    NAME_EXPIRATION = 36000
+
 
 class BitcoinRegtest(BitcoinTestnet):
 
@@ -145,6 +149,8 @@ class BitcoinRegtest(BitcoinTestnet):
     DEFAULT_SERVERS = read_json('servers_regtest.json', {})
     CHECKPOINTS = []
     LN_DNS_SEEDS = []
+
+    NAME_EXPIRATION = 30
 
 
 class BitcoinSimnet(BitcoinTestnet):

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -25,6 +25,8 @@
 
 from typing import Dict
 
+from . import constants
+
 def split_name_script(decoded):
     # This case happens if a script was malformed and couldn't be decoded by
     # transaction.get_address_from_output_script.
@@ -467,7 +469,7 @@ def name_new_mature_in(name_height, chain_height):
 
 def name_expires_in(name_height, chain_height):
     # Names expire at 36000 confirmations.
-    return blocks_remaining_until_confirmations(name_height, chain_height, 36000)
+    return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_EXPIRATION)
 
 def name_expiration_datetime_estimate(name_height, chain_height, chain_unixtime):
     expiration_blocks = name_expires_in(name_height, chain_height)


### PR DESCRIPTION
Add the number of blocks before names expire as network constant rather than hardcoding it in place, and change it to 30 on regtest.