### PR TITLE
Rebrand genesis block hash in Lightning unit tests

### DIFF
--- a/electrum_nmc/electrum/tests/address_conversion.py
+++ b/electrum_nmc/electrum/tests/address_conversion.py
@@ -33,6 +33,7 @@ but the code under test requires the Namecoin forms."""
 from electrum import bitcoin
 from electrum.constants import BitcoinMainnet, BitcoinTestnet
 from electrum import segwit_addr
+from electrum.util import bfh
 
 
 def frombtc(inp: str) -> str:
@@ -65,6 +66,14 @@ def frombtc(inp: str) -> str:
     # Handle bech32 lightning addresses.
     if inp[:4].lower() == "lnbc":
         return convert_ln_bech32(inp, BitcoinMainnet.SEGWIT_HRP)
+
+    # Handle genesis block hashes, e.g. from Lightning messages
+    bitcoin_mainnet_rev_genesis = bitcoin.rev_hex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
+    if bitcoin_mainnet_rev_genesis in inp:
+        return inp.replace(bitcoin_mainnet_rev_genesis, bitcoin.rev_hex(BitcoinMainnet.GENESIS))
+    bitcoin_testnet_rev_genesis = bitcoin.rev_hex("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943")
+    if bitcoin_testnet_rev_genesis in inp:
+        return inp.replace(bitcoin_testnet_rev_genesis, bitcoin.rev_hex(BitcoinTestnet.GENESIS))
 
     # Otherwise, try to base58-decode it and then look at the version to
     # determine what it could have been.
@@ -112,3 +121,14 @@ def convert_ln_bech32(inp: str, new_base_hrp: str) -> str:
 
     new_hrp = "ln" + new_base_hrp + old_hrp[4:]
     return segwit_addr.bech32_encode(new_hrp, data)
+
+def frombtcbytes(inp: bytes) -> bytes:
+    # Handle genesis block hashes, e.g. from Lightning messages
+    bitcoin_mainnet_rev_genesis = bfh(bitcoin.rev_hex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"))
+    if bitcoin_mainnet_rev_genesis in inp:
+        return inp.replace(bitcoin_mainnet_rev_genesis, BitcoinMainnet.rev_genesis_bytes())
+    bitcoin_testnet_rev_genesis = bfh(bitcoin.rev_hex("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"))
+    if bitcoin_testnet_rev_genesis in inp:
+        return inp.replace(bitcoin_testnet_rev_genesis, BitcoinTestnet.rev_genesis_bytes())
+
+    raise AssertionError(f"Invalid input for format conversion: {inp}")

--- a/electrum_nmc/electrum/tests/test_lnmsg.py
+++ b/electrum_nmc/electrum/tests/test_lnmsg.py
@@ -10,6 +10,8 @@ from electrum import constants
 
 from . import TestCaseForTestnet
 
+from .address_conversion import frombtc, frombtcbytes
+
 
 class TestLNMsg(TestCaseForTestnet):
 
@@ -182,7 +184,7 @@ class TestLNMsg(TestCaseForTestnet):
 
     def test_encode_decode_msg__missing_mandatory_field_gets_set_to_zeroes(self):
         # "channel_update": "signature" missing -> gets set to zeroes
-        self.assertEqual(bfh("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00"),
+        self.assertEqual(bfh(frombtc("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00")),
                          encode_msg(
                              "channel_update",
                              short_channel_id=ShortChannelID.from_components(54321, 111, 2),
@@ -197,7 +199,7 @@ class TestLNMsg(TestCaseForTestnet):
                              timestamp=1584320643,
                          ))
         self.assertEqual(('channel_update',
-                         {'chain_hash': b'CI\x7f\xd7\xf8&\x95q\x08\xf4\xa3\x0f\xd9\xce\xc3\xae\xbay\x97 \x84\xe9\x0e\xad\x01\xea3\t\x00\x00\x00\x00',
+                         {'chain_hash': frombtcbytes(b'CI\x7f\xd7\xf8&\x95q\x08\xf4\xa3\x0f\xd9\xce\xc3\xae\xbay\x97 \x84\xe9\x0e\xad\x01\xea3\t\x00\x00\x00\x00'),
                           'channel_flags': b'\x00',
                           'cltv_expiry_delta': 144,
                           'fee_base_msat': 500,
@@ -209,11 +211,11 @@ class TestLNMsg(TestCaseForTestnet):
                           'signature': bytes(64),
                           'timestamp': 1584320643}
                           ),
-                         decode_msg(bfh("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00")))
+                         decode_msg(bfh(frombtc("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00"))))
 
     def test_encode_decode_msg__missing_optional_field_will_not_appear_in_decoded_dict(self):
         # "channel_update": optional field "htlc_maximum_msat" missing -> does not get put into dict
-        self.assertEqual(bfh("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023"),
+        self.assertEqual(bfh(frombtc("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023")),
                          encode_msg(
                              "channel_update",
                              short_channel_id=ShortChannelID.from_components(54321, 111, 2),
@@ -227,7 +229,7 @@ class TestLNMsg(TestCaseForTestnet):
                              timestamp=1584320643,
                          ))
         self.assertEqual(('channel_update',
-                         {'chain_hash': b'CI\x7f\xd7\xf8&\x95q\x08\xf4\xa3\x0f\xd9\xce\xc3\xae\xbay\x97 \x84\xe9\x0e\xad\x01\xea3\t\x00\x00\x00\x00',
+                         {'chain_hash': frombtcbytes(b'CI\x7f\xd7\xf8&\x95q\x08\xf4\xa3\x0f\xd9\xce\xc3\xae\xbay\x97 \x84\xe9\x0e\xad\x01\xea3\t\x00\x00\x00\x00'),
                           'channel_flags': b'\x00',
                           'cltv_expiry_delta': 144,
                           'fee_base_msat': 500,
@@ -238,10 +240,10 @@ class TestLNMsg(TestCaseForTestnet):
                           'signature': bytes(64),
                           'timestamp': 1584320643}
                           ),
-                         decode_msg(bfh("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023")))
+                         decode_msg(bfh(frombtc("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023"))))
 
     def test_encode_decode_msg__ints_can_be_passed_as_bytes(self):
-        self.assertEqual(bfh("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00"),
+        self.assertEqual(bfh(frombtc("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00")),
                          encode_msg(
                              "channel_update",
                              short_channel_id=ShortChannelID.from_components(54321, 111, 2),
@@ -256,7 +258,7 @@ class TestLNMsg(TestCaseForTestnet):
                              timestamp=int.to_bytes(1584320643, length=4, byteorder="big", signed=False),
                          ))
         self.assertEqual(('channel_update',
-                         {'chain_hash': b'CI\x7f\xd7\xf8&\x95q\x08\xf4\xa3\x0f\xd9\xce\xc3\xae\xbay\x97 \x84\xe9\x0e\xad\x01\xea3\t\x00\x00\x00\x00',
+                         {'chain_hash': frombtcbytes(b'CI\x7f\xd7\xf8&\x95q\x08\xf4\xa3\x0f\xd9\xce\xc3\xae\xbay\x97 \x84\xe9\x0e\xad\x01\xea3\t\x00\x00\x00\x00'),
                           'channel_flags': b'\x00',
                           'cltv_expiry_delta': 144,
                           'fee_base_msat': 500,
@@ -268,7 +270,7 @@ class TestLNMsg(TestCaseForTestnet):
                           'signature': bytes(64),
                           'timestamp': 1584320643}
                           ),
-                         decode_msg(bfh("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00")))
+                         decode_msg(bfh(frombtc("01020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea33090000000000d43100006f00025e6ed0830100009000000000000000c8000001f400000023000000003b9aca00"))))
         # "htlc_minimum_msat" is passed as bytes but with incorrect length
         with self.assertRaises(UnexpectedFieldSizeForEncoder):
             encode_msg(


### PR DESCRIPTION
Fixes https://github.com/namecoin/electrum-nmc/issues/262