### PR TITLE
Fix wallet for name_list

### DIFF
--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -375,7 +375,7 @@ class Commands:
         """List unspent name outputs. Returns the list of unspent name_anyupdate
         outputs in your wallet."""
 
-        coins = await self.listunspent(wallet)
+        coins = await self.listunspent(wallet=wallet)
 
         result = []
 


### PR DESCRIPTION
The command decorators expect a wallet argument to be passed explicitly as key-word argument, or else the wallet handling does not work properly.  Make sure that `name_list` passes the wallet as such when calling through to `listunspent`.

Without this, `name_list` complained about missing wallet.  With this, `name_list` works correctly for me with current master and on regtest.