### PR TITLE
AuxPoW: Remove calculate_merkle_root

### DIFF
--- a/electrum/auxpow.py
+++ b/electrum/auxpow.py
@@ -49,6 +49,7 @@ from . import blockchain
 from .bitcoin import hash_encode, hash_decode
 from . import constants
 from .crypto import sha256d
+from .merkle import hash_merkle_root
 from . import transaction
 from .transaction import BCDataStream, Transaction, TxOutput, TYPE_SCRIPT
 from .util import bfh, bh2u
@@ -161,24 +162,6 @@ def hash_parent_header(header):
 
     return blockchain.hash_header(header['auxpow']['parent_header'])
 
-# Reimplementation of btcutils.check_merkle_branch from Electrum-DOGE.
-# btcutils seems to have an unclear license and no obvious Git repo, so it
-# seemed wiser to re-implement.
-# This re-implementation is roughly based on libdohj's calculateMerkleRoot.
-def calculate_merkle_root(leaf, merkle_branch, index):
-    target = hash_decode(leaf)
-    mask = index
-
-    for merkle_step in merkle_branch:
-        if mask & 1 == 0: # 0 means it goes on the right
-            data_to_hash = target + hash_decode(merkle_step)
-        else:
-            data_to_hash = hash_decode(merkle_step) + target
-        target = sha256d(data_to_hash)
-        mask = mask >> 1
-
-    return hash_encode(target)
-
 # Copied from Electrum-DOGE
 # TODO: Audit this function carefully.
 # https://github.com/kR105/i0coin/compare/bitcoin:master...master#diff-610df86e65fce009eb271c2a4f7394ccR262
@@ -229,12 +212,12 @@ def verify_auxpow(header):
     #std::reverse(vchRootHash.begin(), vchRootHash.end()); // correct endian
 
     # Check that the chain merkle root is in the coinbase
-    root_hash_bytes = bfh(calculate_merkle_root(auxhash, chain_merkle_branch, chain_index))
+    root_hash_bytes = bfh(hash_merkle_root(chain_merkle_branch, auxhash, chain_index))
 
     # Check that we are in the parent block merkle tree
     # if (CBlock::CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex) != parentBlock.hashMerkleRoot)
     #    return error("Aux POW merkle root incorrect");
-    if (calculate_merkle_root(coinbase_hash, coinbase_merkle_branch, coinbase_index) != parent_block['merkle_root']):
+    if (hash_merkle_root(coinbase_merkle_branch, coinbase_hash, coinbase_index) != parent_block['merkle_root']):
         raise AuxPoWBadCoinbaseMerkleBranchError("Aux POW merkle root incorrect")
 
     #// Check that there is at least one input.

--- a/electrum/lnverifier.py
+++ b/electrum/lnverifier.py
@@ -34,7 +34,8 @@ from . import ecc
 from . import constants
 from .util import bh2u, bfh, NetworkJobOnDefaultServer
 from .lnutil import funding_output_script_from_keys, ShortChannelID
-from .verifier import verify_tx_is_in_block, MerkleVerificationFailure
+from .verifier import verify_tx_is_in_block
+from .merkle import MerkleVerificationFailure
 from .transaction import Transaction
 from .interface import GracefulDisconnect
 from .crypto import sha256d

--- a/electrum/merkle.py
+++ b/electrum/merkle.py
@@ -1,0 +1,67 @@
+# Electrum - Lightweight Bitcoin Client
+# Copyright (c) 2012 Thomas Voegtlin
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Sequence
+
+from .util import bh2u
+from .crypto import sha256d
+from .bitcoin import hash_decode, hash_encode
+from .transaction import Transaction
+
+class MerkleVerificationFailure(Exception): pass
+class InnerNodeOfSpvProofIsValidTx(MerkleVerificationFailure): pass
+
+def hash_merkle_root(merkle_branch: Sequence[str], tx_hash: str, leaf_pos_in_tree: int):
+    """Return calculated merkle root."""
+    try:
+        h = hash_decode(tx_hash)
+        merkle_branch_bytes = [hash_decode(item) for item in merkle_branch]
+        leaf_pos_in_tree = int(leaf_pos_in_tree)  # raise if invalid
+    except Exception as e:
+        raise MerkleVerificationFailure(e)
+    if leaf_pos_in_tree < 0:
+        raise MerkleVerificationFailure('leaf_pos_in_tree must be non-negative')
+    index = leaf_pos_in_tree
+    for item in merkle_branch_bytes:
+        if len(item) != 32:
+            raise MerkleVerificationFailure('all merkle branch items have to 32 bytes long')
+        inner_node = (item + h) if (index & 1) else (h + item)
+        _raise_if_valid_tx(bh2u(inner_node))
+        h = sha256d(inner_node)
+        index >>= 1
+    if index != 0:
+        raise MerkleVerificationFailure(f'leaf_pos_in_tree too large for branch')
+    return hash_encode(h)
+
+def _raise_if_valid_tx(raw_tx: str):
+    # If an inner node of the merkle proof is also a valid tx, chances are, this is an attack.
+    # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-June/016105.html
+    # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/attachments/20180609/9f4f5b1f/attachment-0001.pdf
+    # https://bitcoin.stackexchange.com/questions/76121/how-is-the-leaf-node-weakness-in-merkle-trees-exploitable/76122#76122
+    tx = Transaction(raw_tx)
+    try:
+        tx.deserialize()
+    except:
+        pass
+    else:
+        raise InnerNodeOfSpvProofIsValidTx()

--- a/electrum/tests/test_auxpow.py
+++ b/electrum/tests/test_auxpow.py
@@ -1,4 +1,5 @@
 from electrum import auxpow, blockchain, constants
+from electrum.merkle import hash_merkle_root
 from electrum.util import bfh, bh2u
 
 from . import SequentialTestCase
@@ -265,7 +266,7 @@ def update_merkle_root_to_match_coinbase(auxpow_header):
 
     revised_coinbase_txid = auxpow.fast_txid(coinbase)
     revised_merkle_branch = [revised_coinbase_txid]
-    revised_merkle_root = auxpow.calculate_merkle_root(revised_coinbase_txid, revised_merkle_branch, auxpow_header['coinbase_merkle_index'])
+    revised_merkle_root = hash_merkle_root(revised_merkle_branch, revised_coinbase_txid, auxpow_header['coinbase_merkle_index'])
 
     auxpow_header['parent_header']['merkle_root'] = revised_merkle_root
     auxpow_header['coinbase_merkle_branch'] = revised_merkle_branch

--- a/electrum/tests/test_verifier.py
+++ b/electrum/tests/test_verifier.py
@@ -3,7 +3,7 @@
 from electrum.bitcoin import hash_encode
 from electrum.transaction import Transaction
 from electrum.util import bfh
-from electrum.verifier import SPV, InnerNodeOfSpvProofIsValidTx
+from electrum.merkle import hash_merkle_root, InnerNodeOfSpvProofIsValidTx
 
 from . import TestCaseForTestnet
 
@@ -27,7 +27,7 @@ class VerifierTestCase(TestCaseForTestnet):
         """Actually mined 64 byte tx should not raise."""
         t_tx = Transaction(VALID_64_BYTE_TX)
         t_tx_hash = t_tx.txid()
-        self.assertEqual(MERKLE_ROOT, SPV.hash_merkle_root(MERKLE_BRANCH, t_tx_hash, 3))
+        self.assertEqual(MERKLE_ROOT, hash_merkle_root(MERKLE_BRANCH, t_tx_hash, 3))
 
     def test_verify_fail_f_tx_odd(self):
         """Raise if inner node of merkle branch is valid tx. ('odd' fake leaf position)"""
@@ -37,7 +37,7 @@ class VerifierTestCase(TestCaseForTestnet):
         # last 32 bytes of T encoded as hash
         f_tx_hash = hash_encode(bfh(VALID_64_BYTE_TX[64:]))
         with self.assertRaises(InnerNodeOfSpvProofIsValidTx):
-            SPV.hash_merkle_root(fake_mbranch, f_tx_hash, 7)
+            hash_merkle_root(fake_mbranch, f_tx_hash, 7)
 
     def test_verify_fail_f_tx_even(self):
         """Raise if inner node of merkle branch is valid tx. ('even' fake leaf position)"""
@@ -47,4 +47,4 @@ class VerifierTestCase(TestCaseForTestnet):
         # first 32 bytes of T encoded as hash
         f_tx_hash = hash_encode(bfh(VALID_64_BYTE_TX[:64]))
         with self.assertRaises(InnerNodeOfSpvProofIsValidTx):
-            SPV.hash_merkle_root(fake_mbranch, f_tx_hash, 6)
+            hash_merkle_root(fake_mbranch, f_tx_hash, 6)

--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -33,6 +33,7 @@ from .transaction import Transaction
 from .blockchain import hash_header
 from .interface import GracefulDisconnect
 from .network import UntrustedServerReturnedError
+from .merkle import hash_merkle_root, MerkleVerificationFailure
 from . import constants
 
 if TYPE_CHECKING:
@@ -40,10 +41,8 @@ if TYPE_CHECKING:
     from .address_synchronizer import AddressSynchronizer
 
 
-class MerkleVerificationFailure(Exception): pass
 class MissingBlockHeader(MerkleVerificationFailure): pass
 class MerkleRootMismatch(MerkleVerificationFailure): pass
-class InnerNodeOfSpvProofIsValidTx(MerkleVerificationFailure): pass
 
 
 class SPV(NetworkJobOnDefaultServer):
@@ -134,43 +133,6 @@ class SPV(NetworkJobOnDefaultServer):
                               header_hash=header_hash)
         self.wallet.add_verified_tx(tx_hash, tx_info)
 
-    @classmethod
-    def hash_merkle_root(cls, merkle_branch: Sequence[str], tx_hash: str, leaf_pos_in_tree: int):
-        """Return calculated merkle root."""
-        try:
-            h = hash_decode(tx_hash)
-            merkle_branch_bytes = [hash_decode(item) for item in merkle_branch]
-            leaf_pos_in_tree = int(leaf_pos_in_tree)  # raise if invalid
-        except Exception as e:
-            raise MerkleVerificationFailure(e)
-        if leaf_pos_in_tree < 0:
-            raise MerkleVerificationFailure('leaf_pos_in_tree must be non-negative')
-        index = leaf_pos_in_tree
-        for item in merkle_branch_bytes:
-            if len(item) != 32:
-                raise MerkleVerificationFailure('all merkle branch items have to 32 bytes long')
-            inner_node = (item + h) if (index & 1) else (h + item)
-            cls._raise_if_valid_tx(bh2u(inner_node))
-            h = sha256d(inner_node)
-            index >>= 1
-        if index != 0:
-            raise MerkleVerificationFailure(f'leaf_pos_in_tree too large for branch')
-        return hash_encode(h)
-
-    @classmethod
-    def _raise_if_valid_tx(cls, raw_tx: str):
-        # If an inner node of the merkle proof is also a valid tx, chances are, this is an attack.
-        # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-June/016105.html
-        # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/attachments/20180609/9f4f5b1f/attachment-0001.pdf
-        # https://bitcoin.stackexchange.com/questions/76121/how-is-the-leaf-node-weakness-in-merkle-trees-exploitable/76122#76122
-        tx = Transaction(raw_tx)
-        try:
-            tx.deserialize()
-        except:
-            pass
-        else:
-            raise InnerNodeOfSpvProofIsValidTx()
-
     async def _maybe_undo_verifications(self):
         old_chain = self.blockchain
         cur_chain = self.network.blockchain()
@@ -200,7 +162,7 @@ def verify_tx_is_in_block(tx_hash: str, merkle_branch: Sequence[str],
                                  .format(tx_hash, block_height))
     if len(merkle_branch) > 30:
         raise MerkleVerificationFailure(f"merkle branch too long: {len(merkle_branch)}")
-    calc_merkle_root = SPV.hash_merkle_root(merkle_branch, tx_hash, leaf_pos_in_tree)
+    calc_merkle_root = hash_merkle_root(merkle_branch, tx_hash, leaf_pos_in_tree)
     if block_header.get('merkle_root') != calc_merkle_root:
         raise MerkleRootMismatch("merkle verification failed for {} ({} != {})".format(
             tx_hash, block_header.get('merkle_root'), calc_merkle_root))


### PR DESCRIPTION
It duplicates functionality of `SPV.hash_merkle_root`.