### PR TITLE
Add name suspensions

### DIFF
--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -45,7 +45,7 @@ from . import bitcoin
 from .bitcoin import is_address,  hash_160, COIN
 from .bip32 import BIP32Node
 from .i18n import _
-from .names import build_name_commitment, build_name_new, format_name_identifier, name_expiration_datetime_estimate, name_identifier_to_scripthash, OP_NAME_NEW, OP_NAME_FIRSTUPDATE, OP_NAME_UPDATE, validate_value_length
+from .names import build_name_commitment, build_name_new, format_name_identifier, name_expiration_datetime_estimate, name_identifier_to_scripthash, name_suspends_in, OP_NAME_NEW, OP_NAME_FIRSTUPDATE, OP_NAME_UPDATE, validate_value_length
 from .verifier import verify_tx_is_in_block
 from .transaction import (Transaction, multisig_script, TxOutput, PartialTransaction, PartialTxOutput,
                           tx_from_any, PartialTxInput, TxOutpoint)
@@ -78,13 +78,19 @@ class NotSynchronizedException(Exception):
     pass
 
 
-class NameNotFoundError(Exception):
+class NameNotResolvableError(Exception):
+    pass
+
+class NameNotFoundError(NameNotResolvableError):
     pass
 
 class NameUnconfirmedError(NameNotFoundError):
     pass
 
 class NameExpiredError(NameNotFoundError):
+    pass
+
+class NameSuspendedError(NameNotResolvableError):
     pass
 
 class NameNeverExistedError(NameNotFoundError):
@@ -423,6 +429,9 @@ class Commands:
             expires_in, expires_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'])
             expired = expires_in <= 0 if expires_in is not None else None
 
+            suspends_in, suspends_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'], blocks_func=name_suspends_in)
+            suspended = suspends_in <= 0 if suspends_in is not None else None
+
             is_mine = wallet.is_mine(address)
 
             result_item = {
@@ -437,6 +446,9 @@ class Commands:
                 "expires_in": expires_in,
                 "expires_time": round(expires_time.timestamp()),
                 "expired": expired,
+                "suspends_in": suspends_in,
+                "suspends_time": round(suspends_time.timestamp()),
+                "suspended": suspended,
                 "ismine": is_mine,
             }
             result.append(result_item)
@@ -747,6 +759,8 @@ class Commands:
                 show = await self.name_show(identifier)
             except NameNotFoundError:
                 name_exists = False
+            except NameSuspendedError:
+                pass
             if name_exists:
                 raise NameAlreadyExistsError("The name is already registered")
 
@@ -1386,12 +1400,15 @@ class Commands:
         # 18 server confirmations but under 12 local confirmations, then we're
         # probably still syncing, and we error.
         unexpired_height = max_chain_height - constants.net.NAME_EXPIRATION + 1
+        unsuspended_height = max_chain_height - constants.net.NAME_SUSPENSION + 1
         unverified_height = local_chain_height - 12 + 1
         unmined_height = max_chain_height - 18 + 1
 
         tx_best = None
         expired_tx_exists = False
         expired_tx_height = None
+        suspended_tx_exists = False
+        suspended_tx_height = None
         unmined_tx_exists = False
         unmined_tx_height = None
         for tx_candidate in txs[::-1]:
@@ -1403,6 +1420,15 @@ class Commands:
                 # we see.
                 if expired_tx_height is None:
                     expired_tx_height = tx_candidate["height"]
+                continue
+            if tx_candidate["height"] < unsuspended_height:
+                # Transaction is suspended.  Skip.
+                suspended_tx_exists = True
+                # We want to log the *latest* suspended height.  We're iterating
+                # in reverse chronological order, so we only take the first one
+                # we see.
+                if suspended_tx_height is None:
+                    suspended_tx_height = tx_candidate["height"]
                 continue
             if tx_candidate["height"] > unverified_height:
                 # Transaction doesn't have enough verified depth.  What we do
@@ -1428,6 +1454,8 @@ class Commands:
 
         if unmined_tx_exists:
             raise NameUnconfirmedError('Name is purportedly unconfirmed (registration height {}, latest verified height {})'.format(unmined_tx_height, unverified_height))
+        if suspended_tx_exists:
+            raise NameSuspendedError("Name is purportedly suspended (latest renewal height {}, latest unsuspended height {})".format(suspended_tx_height, unsuspended_height))
         if expired_tx_exists:
             raise NameExpiredError("Name is purportedly expired (latest renewal height {}, latest unexpired height {})".format(expired_tx_height, unexpired_height))
         if tx_best is None:
@@ -1489,6 +1517,8 @@ class Commands:
 
                     expires_in, expires_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'])
 
+                    suspends_in, suspends_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'], blocks_func=name_suspends_in)
+
                     is_mine = None
                     if wallet:
                         is_mine = wallet.is_mine(o.address)
@@ -1505,6 +1535,9 @@ class Commands:
                         "expires_in": expires_in,
                         "expires_time": round(expires_time.timestamp()),
                         "expired": False,
+                        "suspends_in": suspends_in,
+                        "suspends_time": round(suspends_time.timestamp()),
+                        "suspended": False,
                         "ismine": is_mine,
                     }
 

--- a/electrum_nmc/electrum/constants.py
+++ b/electrum_nmc/electrum/constants.py
@@ -102,6 +102,7 @@ class BitcoinMainnet(AbstractNet):
     AUXPOW_START_HEIGHT = 19200
 
     NAME_EXPIRATION = 36000
+    NAME_SUSPENSION = NAME_EXPIRATION - 2 * 2016
 
 
 class BitcoinTestnet(AbstractNet):
@@ -140,6 +141,7 @@ class BitcoinTestnet(AbstractNet):
     AUXPOW_START_HEIGHT = 0
 
     NAME_EXPIRATION = 36000
+    NAME_SUSPENSION = NAME_EXPIRATION - 2 * 2016
 
 
 class BitcoinRegtest(BitcoinTestnet):
@@ -151,6 +153,7 @@ class BitcoinRegtest(BitcoinTestnet):
     LN_DNS_SEEDS = []
 
     NAME_EXPIRATION = 30
+    NAME_SUSPENSION = NAME_EXPIRATION - 2 * 2
 
 
 class BitcoinSimnet(BitcoinTestnet):

--- a/electrum_nmc/electrum/gui/qt/main_window.py
+++ b/electrum_nmc/electrum/gui/qt/main_window.py
@@ -3381,6 +3381,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         except util.BitcoinException:
             # This happens if the name identifier exceeded the 255-byte limit.
             name_valid = False
+        except commands.NameSuspendedError:
+            # TODO: Check "ismine"
+            pass
         except BestEffortRequestFailed as e:
             msg = repr(e)
             self.show_error(msg)

--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -34,7 +34,7 @@ from PyQt5.QtWidgets import QAbstractItemView, QMenu
 
 from electrum.commands import NameUpdatedTooRecentlyError
 from electrum.i18n import _
-from electrum.names import blocks_remaining_until_confirmations, format_name_identifier, format_name_value, get_queued_firstupdate_from_new, name_expiration_datetime_estimate, OP_NAME_UPDATE
+from electrum.names import blocks_remaining_until_confirmations, format_name_identifier, format_name_value, get_queued_firstupdate_from_new, name_expiration_datetime_estimate, name_suspends_in, OP_NAME_UPDATE
 from electrum.transaction import PartialTxInput
 from electrum.util import NotEnoughFunds, NoDynamicFeeEstimates, bh2u
 from electrum.wallet import InternalAddressCorruption
@@ -53,13 +53,13 @@ class UNOList(UTXOList):
     class Columns(IntEnum):
         NAME = 0
         VALUE = 1
-        EXPIRES_IN = 2
+        SUSPENDS_IN = 2
         STATUS = 3
 
     headers = {
         Columns.NAME: _('Name'),
         Columns.VALUE: _('Value'),
-        Columns.EXPIRES_IN: _('Expires (Est.)'),
+        Columns.SUSPENDS_IN: _('Suspends (Est.)'),
         Columns.STATUS: _('Status'),
     }
     filter_columns = [Columns.NAME, Columns.VALUE]
@@ -95,6 +95,7 @@ class UNOList(UTXOList):
                 if firstupdate_output.name_op is not None:
                     name_op = firstupdate_output.name_op
             expires_in, expires_datetime = None, None
+            suspends_in, suspends_datetime = None, None
 
             if height is not None and header_at_tip is not None and queue_item is not None:
                 sendwhen_depth = queue_item["sendWhen"]["confirmations"]
@@ -113,8 +114,10 @@ class UNOList(UTXOList):
             # utxo is name_anyupdate
             if header_at_tip is not None:
                 expires_in, expires_datetime = name_expiration_datetime_estimate(height_estimated, header_at_tip['block_height'], header_at_tip['timestamp'])
+                suspends_in, suspends_datetime = name_expiration_datetime_estimate(height_estimated, header_at_tip['block_height'], header_at_tip['timestamp'], blocks_func=name_suspends_in)
             else:
                 expires_in, expires_datetime = None, None
+                suspends_in, suspends_datetime = None, None
 
             if height is not None and height > 0:
                 # utxo is confirmed
@@ -143,16 +146,17 @@ class UNOList(UTXOList):
             value = None
             formatted_value = ''
 
-        formatted_expires_in = ( _('Expires in %d blocks\nDate/time is only an estimate; do not rely on it!')%expires_in) if expires_in is not None else ''
         # Copied from electrum.util.format_time.
         # TODO: Patch upstream to avoid this code duplication.
         formatted_expires_datetime = expires_datetime.isoformat(' ')[:-3] if expires_datetime is not None else ''
+        formatted_suspends_datetime = suspends_datetime.isoformat(' ')[:-3] if suspends_datetime is not None else ''
+        formatted_expires_in = ( _('Suspends in %d blocks\nExpires %s (in %d blocks)\nDate/time is only an estimate; do not rely on it!')%(suspends_in, formatted_expires_datetime, expires_in)) if expires_in is not None else ''
 
         txout = txid + ":%d"%vout
 
         self._utxo_dict[txout] = utxo
 
-        labels = [formatted_name, formatted_value, formatted_expires_datetime, status]
+        labels = [formatted_name, formatted_value, formatted_suspends_datetime, status]
         utxo_item = [QStandardItem(x) for x in labels]
         self.set_editability(utxo_item)
 
@@ -163,7 +167,7 @@ class UNOList(UTXOList):
         utxo_item[self.Columns.NAME].setData(name, Qt.UserRole + USER_ROLE_NAME)
         utxo_item[self.Columns.NAME].setData(value, Qt.UserRole + USER_ROLE_VALUE)
 
-        utxo_item[self.Columns.EXPIRES_IN].setToolTip(formatted_expires_in)
+        utxo_item[self.Columns.SUSPENDS_IN].setToolTip(formatted_expires_in)
 
         address = utxo.address
         if self.wallet.is_frozen_address(address) or self.wallet.is_frozen_coin(utxo):

--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -144,7 +144,9 @@ class UNOList(UTXOList):
             formatted_value = ''
 
         formatted_expires_in = ( _('Expires in %d blocks\nDate/time is only an estimate; do not rely on it!')%expires_in) if expires_in is not None else ''
-        formatted_expires_datetime = expires_datetime.isoformat(' ') if expires_datetime is not None else ''
+        # Copied from electrum.util.format_time.
+        # TODO: Patch upstream to avoid this code duplication.
+        formatted_expires_datetime = expires_datetime.isoformat(' ')[:-3] if expires_datetime is not None else ''
 
         txout = txid + ":%d"%vout
 

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -505,8 +505,11 @@ def name_expires_in(name_height: Optional[int], chain_height) -> Optional[int]:
     # Names expire at 36001 confirmations.
     return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_EXPIRATION + 1)
 
-def name_expiration_datetime_estimate(name_height: Optional[int], chain_height, chain_unixtime):
-    expiration_blocks = name_expires_in(name_height, chain_height)
+def name_suspends_in(name_height: Optional[int], chain_height) -> Optional[int]:
+    return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_SUSPENSION + 1)
+
+def name_expiration_datetime_estimate(name_height: Optional[int], chain_height, chain_unixtime, blocks_func = name_expires_in):
+    expiration_blocks = blocks_func(name_height, chain_height)
 
     if expiration_blocks is None:
         return None, None


### PR DESCRIPTION
This PR introduces a new state for names: "suspended".  Suspended names behave like unexpired names on the consensus layer (i.e. they can only be updated by their owner), but behave like expired names on the policy layer (i.e. they resolve as NXDOMAIN).  The idea is that if a user forgets to renew their name on time, it will be suspended, which will make their domain inaccessible; this will hopefully get their attention before the name expires.  This decreases the damage associated with forgetting to renew from a permanent hijacking to a temporary DoS.

The grace period between suspension and expiration is 4032 blocks (~4 weeks) for mainnet/testnet, and 4 blocks for regtest.

This PR also tweaks some related parts of the code in order to make them more conducive to name suspensions; most of these extra tweaks are related to how block heights are converted to dates for display.