### PR TITLE
Use exact expiration timestamps when available

### DIFF
--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -426,10 +426,10 @@ class Commands:
             height = coin["height"]
             local_chain_height = self.network.get_local_height()
 
-            expires_in, expires_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'])
+            expires_in, expires_time = name_expiration_datetime_estimate(height, self.network.blockchain())
             expired = expires_in <= 0 if expires_in is not None else None
 
-            suspends_in, suspends_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'], blocks_func=name_suspends_in)
+            suspends_in, suspends_time = name_expiration_datetime_estimate(height, self.network.blockchain(), blocks_func=name_suspends_in)
             suspended = suspends_in <= 0 if suspends_in is not None else None
 
             is_mine = wallet.is_mine(address)
@@ -1531,9 +1531,9 @@ class Commands:
                     # the tx is now verified to represent the identifier at a
                     # safe height in the blockchain
 
-                    expires_in, expires_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'])
+                    expires_in, expires_time = name_expiration_datetime_estimate(height, self.network.blockchain())
 
-                    suspends_in, suspends_time = name_expiration_datetime_estimate(height, local_chain_height, self.network.blockchain().header_at_tip()['timestamp'], blocks_func=name_suspends_in)
+                    suspends_in, suspends_time = name_expiration_datetime_estimate(height, self.network.blockchain(), blocks_func=name_suspends_in)
 
                     is_mine = None
                     if wallet:

--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -113,8 +113,8 @@ class UNOList(UTXOList):
         else:
             # utxo is name_anyupdate
             if header_at_tip is not None:
-                expires_in, expires_datetime = name_expiration_datetime_estimate(height_estimated, header_at_tip['block_height'], header_at_tip['timestamp'])
-                suspends_in, suspends_datetime = name_expiration_datetime_estimate(height_estimated, header_at_tip['block_height'], header_at_tip['timestamp'], blocks_func=name_suspends_in)
+                expires_in, expires_datetime = name_expiration_datetime_estimate(height_estimated, self.network.blockchain())
+                suspends_in, suspends_datetime = name_expiration_datetime_estimate(height_estimated, self.network.blockchain(), blocks_func=name_suspends_in)
             else:
                 expires_in, expires_datetime = None, None
                 suspends_in, suspends_datetime = None, None

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -508,15 +508,15 @@ def name_expires_in(name_height: Optional[int], chain_height) -> Optional[int]:
 def name_suspends_in(name_height: Optional[int], chain_height) -> Optional[int]:
     return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_SUSPENSION + 1)
 
-def name_expiration_datetime_estimate(name_height: Optional[int], chain_height, chain_unixtime, blocks_func = name_expires_in):
-    expiration_blocks = blocks_func(name_height, chain_height)
+def name_expiration_datetime_estimate(name_height: Optional[int], chain, blocks_func = name_expires_in):
+    expiration_blocks = blocks_func(name_height, chain.header_at_tip()['block_height'])
 
     if expiration_blocks is None:
         return None, None
 
     block_timedelta = timedelta(minutes=10)
     expiration_timedelta = expiration_blocks * block_timedelta
-    chain_datetime = datetime.fromtimestamp(chain_unixtime)
+    chain_datetime = datetime.fromtimestamp(chain.header_at_tip()['timestamp'])
     return expiration_blocks, chain_datetime + expiration_timedelta
 
 def get_domain_records(domain, value):


### PR DESCRIPTION
Fixes inaccurate expiration estimates for expired names.