### PR TITLE
Rename "suspended" state to "semi-expired"

### DIFF
--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -1471,7 +1471,7 @@ class Commands:
         if unmined_tx_exists:
             raise NameUnconfirmedError('Name is purportedly unconfirmed (registration height {}, latest verified height {})'.format(unmined_tx_height, unverified_height))
         if semi_expired_tx_exists:
-            raise NameSemiExpiredError("Name is purportedly semi-expired (latest renewal height {}, latest un-semi-expired height {})".format(semi_expired_tx_height, un_semi_expired_height))
+            raise NameSemiExpiredError("Name is purportedly semi-expired (latest renewal height {}, latest un-semi-expired height {}); if this name is yours, renew it ASAP to restore resolution and avoid losing ownership of the name".format(semi_expired_tx_height, un_semi_expired_height))
         if expired_tx_exists:
             raise NameExpiredError("Name is purportedly expired (latest renewal height {}, latest unexpired height {})".format(expired_tx_height, unexpired_height))
         if tx_best is None:

--- a/electrum_nmc/electrum/commands.py
+++ b/electrum_nmc/electrum/commands.py
@@ -45,7 +45,7 @@ from . import bitcoin
 from .bitcoin import is_address,  hash_160, COIN
 from .bip32 import BIP32Node
 from .i18n import _
-from .names import build_name_commitment, build_name_new, format_name_identifier, name_expiration_datetime_estimate, name_identifier_to_scripthash, name_suspends_in, OP_NAME_NEW, OP_NAME_FIRSTUPDATE, OP_NAME_UPDATE, validate_value_length
+from .names import build_name_commitment, build_name_new, format_name_identifier, name_expiration_datetime_estimate, name_identifier_to_scripthash, name_semi_expires_in, OP_NAME_NEW, OP_NAME_FIRSTUPDATE, OP_NAME_UPDATE, validate_value_length
 from .verifier import verify_tx_is_in_block
 from .transaction import (Transaction, multisig_script, TxOutput, PartialTransaction, PartialTxOutput,
                           tx_from_any, PartialTxInput, TxOutpoint)
@@ -90,7 +90,7 @@ class NameUnconfirmedError(NameNotFoundError):
 class NameExpiredError(NameNotFoundError):
     pass
 
-class NameSuspendedError(NameNotResolvableError):
+class NameSemiExpiredError(NameNotResolvableError):
     pass
 
 class NameNeverExistedError(NameNotFoundError):
@@ -429,8 +429,8 @@ class Commands:
             expires_in, expires_time = name_expiration_datetime_estimate(height, self.network.blockchain())
             expired = expires_in <= 0 if expires_in is not None else None
 
-            suspends_in, suspends_time = name_expiration_datetime_estimate(height, self.network.blockchain(), blocks_func=name_suspends_in)
-            suspended = suspends_in <= 0 if suspends_in is not None else None
+            semi_expires_in, semi_expires_time = name_expiration_datetime_estimate(height, self.network.blockchain(), blocks_func=name_semi_expires_in)
+            semi_expired = semi_expires_in <= 0 if semi_expires_in is not None else None
 
             is_mine = wallet.is_mine(address)
 
@@ -446,9 +446,9 @@ class Commands:
                 "expires_in": expires_in,
                 "expires_time": round(expires_time.timestamp()),
                 "expired": expired,
-                "suspends_in": suspends_in,
-                "suspends_time": round(suspends_time.timestamp()),
-                "suspended": suspended,
+                "semi_expires_in": semi_expires_in,
+                "semi_expires_time": round(semi_expires_time.timestamp()),
+                "semi_expired": semi_expired,
                 "ismine": is_mine,
             }
             result.append(result_item)
@@ -766,7 +766,7 @@ class Commands:
                 show = await self.name_show(identifier)
             except NameNotFoundError:
                 name_exists = False
-            except NameSuspendedError:
+            except NameSemiExpiredError:
                 pass
             if name_exists:
                 raise NameAlreadyExistsError("The name is already registered")
@@ -1416,15 +1416,15 @@ class Commands:
         # 18 server confirmations but under 12 local confirmations, then we're
         # probably still syncing, and we error.
         unexpired_height = max_chain_height - constants.net.NAME_EXPIRATION + 1
-        unsuspended_height = max_chain_height - constants.net.NAME_SUSPENSION + 1
+        un_semi_expired_height = max_chain_height - constants.net.NAME_SEMI_EXPIRATION + 1
         unverified_height = local_chain_height - 12 + 1
         unmined_height = max_chain_height - 18 + 1
 
         tx_best = None
         expired_tx_exists = False
         expired_tx_height = None
-        suspended_tx_exists = False
-        suspended_tx_height = None
+        semi_expired_tx_exists = False
+        semi_expired_tx_height = None
         unmined_tx_exists = False
         unmined_tx_height = None
         for tx_candidate in txs[::-1]:
@@ -1437,14 +1437,14 @@ class Commands:
                 if expired_tx_height is None:
                     expired_tx_height = tx_candidate["height"]
                 continue
-            if tx_candidate["height"] < unsuspended_height:
-                # Transaction is suspended.  Skip.
-                suspended_tx_exists = True
-                # We want to log the *latest* suspended height.  We're iterating
+            if tx_candidate["height"] < un_semi_expired_height:
+                # Transaction is semi-expired.  Skip.
+                semi_expired_tx_exists = True
+                # We want to log the *latest* semi-expired height.  We're iterating
                 # in reverse chronological order, so we only take the first one
                 # we see.
-                if suspended_tx_height is None:
-                    suspended_tx_height = tx_candidate["height"]
+                if semi_expired_tx_height is None:
+                    semi_expired_tx_height = tx_candidate["height"]
                 continue
             if tx_candidate["height"] > unverified_height:
                 # Transaction doesn't have enough verified depth.  What we do
@@ -1470,8 +1470,8 @@ class Commands:
 
         if unmined_tx_exists:
             raise NameUnconfirmedError('Name is purportedly unconfirmed (registration height {}, latest verified height {})'.format(unmined_tx_height, unverified_height))
-        if suspended_tx_exists:
-            raise NameSuspendedError("Name is purportedly suspended (latest renewal height {}, latest unsuspended height {})".format(suspended_tx_height, unsuspended_height))
+        if semi_expired_tx_exists:
+            raise NameSemiExpiredError("Name is purportedly semi-expired (latest renewal height {}, latest un-semi-expired height {})".format(semi_expired_tx_height, un_semi_expired_height))
         if expired_tx_exists:
             raise NameExpiredError("Name is purportedly expired (latest renewal height {}, latest unexpired height {})".format(expired_tx_height, unexpired_height))
         if tx_best is None:
@@ -1533,7 +1533,7 @@ class Commands:
 
                     expires_in, expires_time = name_expiration_datetime_estimate(height, self.network.blockchain())
 
-                    suspends_in, suspends_time = name_expiration_datetime_estimate(height, self.network.blockchain(), blocks_func=name_suspends_in)
+                    semi_expires_in, semi_expires_time = name_expiration_datetime_estimate(height, self.network.blockchain(), blocks_func=name_semi_expires_in)
 
                     is_mine = None
                     if wallet:
@@ -1551,9 +1551,9 @@ class Commands:
                         "expires_in": expires_in,
                         "expires_time": round(expires_time.timestamp()),
                         "expired": False,
-                        "suspends_in": suspends_in,
-                        "suspends_time": round(suspends_time.timestamp()),
-                        "suspended": False,
+                        "semi_expires_in": semi_expires_in,
+                        "semi_expires_time": round(semi_expires_time.timestamp()),
+                        "semi_expired": False,
                         "ismine": is_mine,
                     }
 

--- a/electrum_nmc/electrum/constants.py
+++ b/electrum_nmc/electrum/constants.py
@@ -102,7 +102,7 @@ class BitcoinMainnet(AbstractNet):
     AUXPOW_START_HEIGHT = 19200
 
     NAME_EXPIRATION = 36000
-    NAME_SUSPENSION = NAME_EXPIRATION - 2 * 2016
+    NAME_SEMI_EXPIRATION = NAME_EXPIRATION - 2 * 2016
 
 
 class BitcoinTestnet(AbstractNet):
@@ -141,7 +141,7 @@ class BitcoinTestnet(AbstractNet):
     AUXPOW_START_HEIGHT = 0
 
     NAME_EXPIRATION = 36000
-    NAME_SUSPENSION = NAME_EXPIRATION - 2 * 2016
+    NAME_SEMI_EXPIRATION = NAME_EXPIRATION - 2 * 2016
 
 
 class BitcoinRegtest(BitcoinTestnet):
@@ -153,7 +153,7 @@ class BitcoinRegtest(BitcoinTestnet):
     LN_DNS_SEEDS = []
 
     NAME_EXPIRATION = 30
-    NAME_SUSPENSION = NAME_EXPIRATION - 2 * 2
+    NAME_SEMI_EXPIRATION = NAME_EXPIRATION - 2 * 2
 
 
 class BitcoinSimnet(BitcoinTestnet):

--- a/electrum_nmc/electrum/gui/qt/main_window.py
+++ b/electrum_nmc/electrum/gui/qt/main_window.py
@@ -3381,7 +3381,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         except util.BitcoinException:
             # This happens if the name identifier exceeded the 255-byte limit.
             name_valid = False
-        except commands.NameSuspendedError:
+        except commands.NameSemiExpiredError:
             # TODO: Check "ismine"
             pass
         except BestEffortRequestFailed as e:

--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -110,7 +110,7 @@ class UNOList(UTXOList):
 
                 minutes_remaining_until_firstupdate_confirmed = 10 * blocks_until_firstupdate_confirmed
 
-                status = _('Registration Pending, ETA ') + str(minutes_remaining_until_firstupdate_confirmed) + _("min")
+                status = _('Registration Pending, ETA %dmin')%minutes_remaining_until_firstupdate_confirmed
             else:
                 status = _('Registration Pending')
         else:
@@ -143,7 +143,7 @@ class UNOList(UTXOList):
                     # utxo is name_firstupdate
                     # TODO: Namecoin: Take into account the fact that
                     # transactions may not be mined in the next block.
-                    status = _('Registration Pending, ETA 10min')
+                    status = _('Registration Pending, ETA %dmin')%10
 
         if 'name' in name_op:
             # utxo is name_anyupdate or a name_new that we've queued a name_firstupdate for
@@ -312,7 +312,7 @@ class UNOList(UTXOList):
                 broadcast(tx)
             except Exception as e:
                 formatted_name = format_name_identifier(identifier)
-                self.parent.show_error(_("Error broadcasting renewal for ") + formatted_name + ": " + str(e))
+                self.parent.show_error(_("Error broadcasting renewal for %s: %s")%(formatted_name, str(e)))
                 continue
 
             # We add the transaction to the wallet explicitly because
@@ -324,7 +324,7 @@ class UNOList(UTXOList):
             status = addtransaction(tx)
             if not status:
                 formatted_name = format_name_identifier(identifier)
-                self.parent.show_error(_("Error adding renewal for ") + formatted_name + _(" to wallet"))
+                self.parent.show_error(_("Error adding renewal for %s to wallet")%formatted_name)
                 continue
 
     def configure_selected_item(self):

--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -89,6 +89,8 @@ class UNOList(UTXOList):
         else:
             height_estimated = height
 
+        status_tooltip = None
+
         if 'name' not in name_op:
             # utxo is name_new
             queue_item, firstupdate_output = get_queued_firstupdate_from_new(self.wallet, txid, vout)
@@ -126,8 +128,10 @@ class UNOList(UTXOList):
                     status = _('Expired')
                 elif semi_expires_in is not None and semi_expires_in <= 0:
                     status = _('Semi-Expired')
+                    status_tooltip = _('This name has stopped resolving because it was not renewed on time.  Renew it ASAP to restore resolution and avoid losing ownership of the name.')
                 elif semi_expires_in is not None and semi_expires_in <= constants.net.NAME_EXPIRATION - constants.net.NAME_SEMI_EXPIRATION:
                     status = _('Semi-Expiring Soon')
+                    status_tooltip = _('This name will stop resolving soon if it is not renewed.  Renew it ASAP to keep it resolving.')
                 else:
                     status = _('Confirmed')
             else:
@@ -176,6 +180,8 @@ class UNOList(UTXOList):
         utxo_item[self.Columns.NAME].setData(value, Qt.UserRole + USER_ROLE_VALUE)
 
         utxo_item[self.Columns.SEMI_EXPIRES_IN].setToolTip(formatted_expires_in)
+        if status_tooltip is not None:
+            utxo_item[self.Columns.STATUS].setToolTip(status_tooltip)
 
         address = utxo.address
         if self.wallet.is_frozen_address(address) or self.wallet.is_frozen_coin(utxo):

--- a/electrum_nmc/electrum/gui/qt/uno_list.py
+++ b/electrum_nmc/electrum/gui/qt/uno_list.py
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import QAbstractItemView, QMenu
 from electrum import constants
 from electrum.commands import NameUpdatedTooRecentlyError
 from electrum.i18n import _
-from electrum.names import blocks_remaining_until_confirmations, format_name_identifier, format_name_value, get_queued_firstupdate_from_new, name_expiration_datetime_estimate, name_suspends_in, OP_NAME_UPDATE
+from electrum.names import blocks_remaining_until_confirmations, format_name_identifier, format_name_value, get_queued_firstupdate_from_new, name_expiration_datetime_estimate, name_semi_expires_in, OP_NAME_UPDATE
 from electrum.transaction import PartialTxInput
 from electrum.util import NotEnoughFunds, NoDynamicFeeEstimates, bh2u
 from electrum.wallet import InternalAddressCorruption
@@ -54,13 +54,13 @@ class UNOList(UTXOList):
     class Columns(IntEnum):
         NAME = 0
         VALUE = 1
-        SUSPENDS_IN = 2
+        SEMI_EXPIRES_IN = 2
         STATUS = 3
 
     headers = {
         Columns.NAME: _('Name'),
         Columns.VALUE: _('Value'),
-        Columns.SUSPENDS_IN: _('Suspends (Est.)'),
+        Columns.SEMI_EXPIRES_IN: _('Semi-Expires (Est.)'),
         Columns.STATUS: _('Status'),
     }
     filter_columns = [Columns.NAME, Columns.VALUE]
@@ -96,7 +96,7 @@ class UNOList(UTXOList):
                 if firstupdate_output.name_op is not None:
                     name_op = firstupdate_output.name_op
             expires_in, expires_datetime = None, None
-            suspends_in, suspends_datetime = None, None
+            semi_expires_in, semi_expires_datetime = None, None
 
             if height is not None and header_at_tip is not None and queue_item is not None:
                 sendwhen_depth = queue_item["sendWhen"]["confirmations"]
@@ -115,19 +115,19 @@ class UNOList(UTXOList):
             # utxo is name_anyupdate
             if header_at_tip is not None:
                 expires_in, expires_datetime = name_expiration_datetime_estimate(height_estimated, self.network.blockchain())
-                suspends_in, suspends_datetime = name_expiration_datetime_estimate(height_estimated, self.network.blockchain(), blocks_func=name_suspends_in)
+                semi_expires_in, semi_expires_datetime = name_expiration_datetime_estimate(height_estimated, self.network.blockchain(), blocks_func=name_semi_expires_in)
             else:
                 expires_in, expires_datetime = None, None
-                suspends_in, suspends_datetime = None, None
+                semi_expires_in, semi_expires_datetime = None, None
 
             if height is not None and height > 0:
                 # utxo is confirmed
                 if expires_in is not None and expires_in <= 0:
                     status = _('Expired')
-                elif suspends_in is not None and suspends_in <= 0:
-                    status = _('Suspended')
-                elif suspends_in is not None and suspends_in <= constants.net.NAME_EXPIRATION - constants.net.NAME_SUSPENSION:
-                    status = _('Suspending Soon')
+                elif semi_expires_in is not None and semi_expires_in <= 0:
+                    status = _('Semi-Expired')
+                elif semi_expires_in is not None and semi_expires_in <= constants.net.NAME_EXPIRATION - constants.net.NAME_SEMI_EXPIRATION:
+                    status = _('Semi-Expiring Soon')
                 else:
                     status = _('Confirmed')
             else:
@@ -157,14 +157,14 @@ class UNOList(UTXOList):
         # Copied from electrum.util.format_time.
         # TODO: Patch upstream to avoid this code duplication.
         formatted_expires_datetime = expires_datetime.isoformat(' ')[:-3] if expires_datetime is not None else ''
-        formatted_suspends_datetime = suspends_datetime.isoformat(' ')[:-3] if suspends_datetime is not None else ''
-        formatted_expires_in = ( _('Suspends in %d blocks\nExpires %s (in %d blocks)\nDate/time is only an estimate; do not rely on it!')%(suspends_in, formatted_expires_datetime, expires_in)) if expires_in is not None else ''
+        formatted_semi_expires_datetime = semi_expires_datetime.isoformat(' ')[:-3] if semi_expires_datetime is not None else ''
+        formatted_expires_in = ( _('Semi-Expires in %d blocks\nExpires %s (in %d blocks)\nDate/time is only an estimate; do not rely on it!')%(semi_expires_in, formatted_expires_datetime, expires_in)) if expires_in is not None else ''
 
         txout = txid + ":%d"%vout
 
         self._utxo_dict[txout] = utxo
 
-        labels = [formatted_name, formatted_value, formatted_suspends_datetime, status]
+        labels = [formatted_name, formatted_value, formatted_semi_expires_datetime, status]
         utxo_item = [QStandardItem(x) for x in labels]
         self.set_editability(utxo_item)
 
@@ -175,7 +175,7 @@ class UNOList(UTXOList):
         utxo_item[self.Columns.NAME].setData(name, Qt.UserRole + USER_ROLE_NAME)
         utxo_item[self.Columns.NAME].setData(value, Qt.UserRole + USER_ROLE_VALUE)
 
-        utxo_item[self.Columns.SUSPENDS_IN].setToolTip(formatted_expires_in)
+        utxo_item[self.Columns.SEMI_EXPIRES_IN].setToolTip(formatted_expires_in)
 
         address = utxo.address
         if self.wallet.is_frozen_address(address) or self.wallet.is_frozen_coin(utxo):

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -505,8 +505,8 @@ def name_expires_in(name_height: Optional[int], chain_height) -> Optional[int]:
     # Names expire at 36001 confirmations.
     return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_EXPIRATION + 1)
 
-def name_suspends_in(name_height: Optional[int], chain_height) -> Optional[int]:
-    return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_SUSPENSION + 1)
+def name_semi_expires_in(name_height: Optional[int], chain_height) -> Optional[int]:
+    return blocks_remaining_until_confirmations(name_height, chain_height, constants.net.NAME_SEMI_EXPIRATION + 1)
 
 def name_expiration_datetime_estimate(name_height: Optional[int], chain, blocks_func = name_expires_in):
     chain_height = chain.header_at_tip()['block_height']


### PR DESCRIPTION
"Suspended" is, in non-Namecoin contexts, sometimes associated with censorship by a 3rd party rather than failure to renew on time.  "Semi-expired" avoids the risk that users will incorrectly infer that their name has been censored.

The criteria for the new state name were:

* Intuitively conveys that the state is temporary, i.e. it will transition to "expired" or "confirmed".
* Intuitively conveys that the name is unresolvable, like "expired".
* Single word (hyphenated is fine) so that it avoids problems when used in JSON-RPC API's.
* Adjective form of a past-tense verb (allows us to conjugate in parallel to "expired").
* Intuitively conveys urgency, so that users won't ignore it.
* Cannot easily be misconstrued as a reference to censorship.

Thanks to (in lexicographic order) Arthur Edelstein, Cyberia Computer Club, Cypherpunks, Cyphrs, Diego Salazar, s7r, Somewhat, and Yanmaani for helping find a better name for this state.

This PR also adds better contextual feedback on the semi-expired state, as per a suggestion from Diego.  It also fixes some i18n bugs that I noticed while implementing this PR.