### PR TITLE
The Namecoin logo is in the public domain.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Electrum-NMC - Lightweight Namecoin client
 
 ::
 
-  Licence: GNU GPLv3+ for Electrum-DOGE components; CC BY 4.0 for Namecoin logo, MIT Licence for all other components
+  Licence: GNU GPLv3+ for Electrum-DOGE components; MIT Licence for all other components
   Author: The Namecoin developers; based on Electrum by Thomas Voegtlin and Electrum-DOGE by The Electrum-DOGE contributors
   Language: Python (>= 3.6)
   Homepage: https://www.namecoin.org/ ; original Electrum Homepage at https://electrum.org/


### PR DESCRIPTION
The Namecoin logo is in the public domain.