### PR TITLE
Validate onion addresses

### DIFF
--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -133,6 +133,8 @@ def validate_value_length(value: bytes):
         raise BitcoinException('value length {} exceeds limit of {}'.format(value_length, value_length_limit))
 
 def validate_onion_address(address: str) -> None:
+    if not address == address.lower():
+        raise ValueError("Invalid onion address: must be in lowercase")
     # Verify and remove ".onion" from the address if present
     if not address.endswith(".onion"):
         raise ValueError("Invalid onion address: missing .onion suffix")
@@ -141,11 +143,8 @@ def validate_onion_address(address: str) -> None:
     address = address[:-len('.onion')]  # Slice slicing to remove the last 6 characters (length of ".onion")
 
     try:
-        # Initialize the bytearray to hold the decoded service ID
-        decoded_service_id = bytearray([0] * V3_ONION_SERVICE_ID_RAW_SIZE)
-
         # Decode the service ID from base32 into the decoded_service_id bytearray
-        decoded_service_id = base64.b32decode(address.encode(), decoded_service_id)
+        decoded_service_id = base64.b32decode(address.upper().encode())
 
         # Check decoded service ID has the expected length
         if len(decoded_service_id) != V3_ONION_SERVICE_ID_RAW_SIZE:
@@ -178,7 +177,6 @@ def calc_onion_truncated_checksum(public_key):
     SHA3_256_BYTES = 256 // 8
 
     hasher = hashlib.sha3_256()
-    assert SHA3_256_BYTES == hasher.digest_size
 
     # Calculate the checksum
     hasher.update(b".onion checksum")
@@ -1469,4 +1467,3 @@ V3_ONION_SERVICE_ID_RAW_SIZE= 35
 V3_ONION_SERVICE_ID_VERSION_OFFSET = 34
 ED25519_PUBLIC_KEY_SIZE = 32
 V3_ONION_SERVICE_ID_CHECKSUM_OFFSET = 32
-BASE32_LENGTH = 32

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -144,7 +144,7 @@ def validate_onion_address(address: str) -> None:
 
     try:
         # Decode the service ID from base32 into the decoded_service_id bytearray
-        decoded_service_id = base64.b32decode(address.upper().encode())
+        decoded_service_id = base64.b32decode(address.encode(), casefold=True)
 
         # Check decoded service ID has the expected length
         if len(decoded_service_id) != V3_ONION_SERVICE_ID_RAW_SIZE:

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -132,6 +132,63 @@ def validate_value_length(value: bytes):
     if value_length > value_length_limit:
         raise BitcoinException('value length {} exceeds limit of {}'.format(value_length, value_length_limit))
 
+def validate_onion_address(address: str) -> None:
+    # Verify and remove ".onion" from the address if present
+    if not address.endswith(".onion"):
+        raise ValueError("Invalid onion address: missing .onion suffix")
+
+    # Remove ".onion" from the address
+    address = address[:-6]  # Slice slicing to remove the last 6 characters (length of ".onion")
+
+    try:
+        # Initialize the bytearray to hold the decoded service ID
+        decoded_service_id = bytearray([0] * V3_ONION_SERVICE_ID_RAW_SIZE)
+
+        # Decode the service ID from base32 into the decoded_service_id bytearray
+        decoded_service_id = base64.b32decode(address.encode(), decoded_service_id)
+
+        # Check decoded service ID has the expected length
+        if len(decoded_service_id) != V3_ONION_SERVICE_ID_RAW_SIZE:
+            raise ValueError("Invalid service ID length")
+
+        # Check the version byte
+        version_byte = decoded_service_id[V3_ONION_SERVICE_ID_VERSION_OFFSET]
+        if version_byte > 0x03:
+            raise ValueError(f"Warning: this is a v{version_byte} onion service, which is newer than the v3 onion services that Electrum-NMC knows how to validate. Please verify that this is what you really meant to enter.")
+
+        if version_byte != 0x03:
+            raise ValueError(f"Obsolete v{version_byte} onion service")
+
+        # Extract the public key from the decoded service ID
+        public_key = bytearray(decoded_service_id[:ED25519_PUBLIC_KEY_SIZE])
+
+        # Calculate the truncated checksum
+        truncated_checksum = calc_truncated_checksum(public_key)
+
+        # Check if the truncated checksum matches the corresponding bytes in the decoded service ID
+        if truncated_checksum[0] != decoded_service_id[V3_ONION_SERVICE_ID_CHECKSUM_OFFSET] or \
+                truncated_checksum[1] != decoded_service_id[V3_ONION_SERVICE_ID_CHECKSUM_OFFSET + 1]:
+            raise ValueError("Invalid checksum")
+
+    except Exception as e:
+        raise ValueError(f"Invalid onion address: {e}")
+
+def calc_truncated_checksum(public_key):
+    # Define the size of the hash in bytes
+    SHA256_BYTES = 256 // 8
+    hash_bytes = bytearray(SHA256_BYTES)
+
+    hasher = hashlib.sha3_256()
+    assert SHA256_BYTES == hasher.digest_size
+
+    # Calculate the checksum
+    hasher.update(b".onion checksum")
+    hasher.update(public_key)
+    hasher.update(bytes([0x03]))
+    hash_bytes = bytearray(hasher.digest())
+
+    return hash_bytes[:2]
+
 def build_name_new(identifier: bytes, salt: bytes = None, address: str = None, password: str = None, wallet = None):
     validate_identifier_length(identifier)
 
@@ -1397,6 +1454,8 @@ from datetime import datetime, timedelta
 import json
 import os
 import re
+import base64
+import hashlib
 
 from .bitcoin import push_script, script_to_scripthash
 from .crypto import hash_160
@@ -1407,3 +1466,8 @@ OP_NAME_NEW = opcodes.OP_1
 OP_NAME_FIRSTUPDATE = opcodes.OP_2
 OP_NAME_UPDATE = opcodes.OP_3
 
+V3_ONION_SERVICE_ID_RAW_SIZE= 35
+V3_ONION_SERVICE_ID_VERSION_OFFSET = 34
+ED25519_PUBLIC_KEY_SIZE = 32
+V3_ONION_SERVICE_ID_CHECKSUM_OFFSET = 32
+BASE32_LENGTH = 32


### PR DESCRIPTION
1. It verifies and removes the ".onion" suffix from the address, raising an error if the suffix is missing.
2. It decodes the base32-encoded service ID from the address and performs various checks to ensure its validity.
3. The version byte of the onion service is checked.
4. The extracted public key is used to calculate a truncated checksum, which is then compared with the corresponding bytes in the decoded service ID.