### PR TITLE
Validate IPV4 & IPV6 addresses

### DIFF
--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -145,6 +145,22 @@ def build_name_new(identifier: bytes, salt: bytes = None, address: str = None, p
 
     return {"op": OP_NAME_NEW, "commitment": commitment}, salt
 
+def validate_ipv4_address(address: str) -> None:
+    try:
+        ipaddress.IPv4Address(address)
+    except ipaddress.AddressValueError as e:
+        raise ValueError(f"Invalid IPv4 address: {e}")
+    except ipaddress.NetmaskValueError as e:
+        raise ValueError(f"Invalid IPv4 netmask: {e}")
+
+def validate_ipv6_address(address: str) -> None:
+    try:
+        ipaddress.IPv6Address(address)
+    except ipaddress.AddressValueError as e:
+        raise ValueError(f"Invalid IPv6 address: {e}")
+    except ipaddress.NetmaskValueError as e:
+        raise ValueError(f"Invalid IPv6 netmask: {e}")
+
 def build_name_commitment(identifier: bytes, salt: bytes) -> bytes:
     preimage = salt + identifier
     commitment = hash_160(preimage)
@@ -1397,6 +1413,7 @@ from datetime import datetime, timedelta
 import json
 import os
 import re
+import ipaddress
 
 from .bitcoin import push_script, script_to_scripthash
 from .crypto import hash_160

--- a/electrum_nmc/electrum/names.py
+++ b/electrum_nmc/electrum/names.py
@@ -155,7 +155,9 @@ def validate_ipv4_address(address: str) -> None:
 
 def validate_ipv6_address(address: str) -> None:
     try:
-        ipaddress.IPv6Address(address)
+        ip = ipaddress.IPv6Address(address)
+        if address != ip.compressed:
+            raise ValueError("IPv6 address should be in compressed form")
     except ipaddress.AddressValueError as e:
         raise ValueError(f"Invalid IPv6 address: {e}")
     except ipaddress.NetmaskValueError as e:


### PR DESCRIPTION
- Imported the `ipaddress` module for IP address manipulation.
- Added `validate_ipv4_address` and `validate_ipv6_address` to validate IPv4 & IPV6 addresses, handling potential exceptions for both invalid addresses and netmasks.