### PR TITLE
Binary encoding (Value)

### DIFF
--- a/electrum_nmc/electrum/gui/qt/forms/configurenamedialog.ui
+++ b/electrum_nmc/electrum/gui/qt/forms/configurenamedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>545</width>
-    <height>304</height>
+    <height>345</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,49 +19,23 @@
   <property name="windowTitle">
    <string>Configure Name</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-     </property>
-     <property name="labelAlignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelNamespace">
-       <property name="text">
-        <string notr="true">TextLabel</string>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="4" column="1">
+      <layout class="QHBoxLayout" name="transferToLayout">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <property name="buddy">
-        <cstring>dataEdit</cstring>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
        </property>
-      </widget>
+       <item>
+        <widget class="QPayToEdit" name="transferTo"/>
+       </item>
+      </layout>
      </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="labelName">
-       <property name="text">
-        <string notr="true">TextLabel</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>16</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>&amp;Data:</string>
@@ -74,17 +48,192 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="label_4">
+     <item row="2" column="2">
+      <widget class="QPushButton" name="btnDNSEditor">
        <property name="text">
-        <string>JSON string, e.g. {&amp;quot;ip&amp;quot;: [&amp;quot;1.2.3.4&amp;quot;, &amp;quot;1.2.3.5&amp;quot;]}&lt;br&gt;See &lt;a href=&quot;https://github.com/namecoin/proposals&quot;&gt;JSON value specifications&lt;/a&gt;.</string>
-       </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
+        <string>DNS Editor…</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelTransferTo">
+       <property name="text">
+        <string>&amp;Transfer to:</string>
+       </property>
+       <property name="buddy">
+        <cstring>transferTo</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>16</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="labelName">
+       <property name="text">
+        <string notr="true">TextLabel</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="minimumSize">
+          <size>
+           <width>350</width>
+           <height>115</height>
+          </size>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="ASCII">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <attribute name="title">
+           <string>ASCII</string>
+          </attribute>
+          <widget class="QLabel" name="label_4">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>30</y>
+             <width>361</width>
+             <height>51</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>JSON string, e.g. {&amp;quot;ip&amp;quot;: [&amp;quot;1.2.3.4&amp;quot;, &amp;quot;1.2.3.5&amp;quot;]}&lt;br&gt;See &lt;a href=&quot;https://github.com/namecoin/proposals&quot;&gt;JSON value specifications&lt;/a&gt;.</string>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+          </widget>
+          <widget class="QWidget" name="layoutWidget">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>342</width>
+             <height>31</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="transferToLayout_3">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <item>
+             <widget class="QLineEdit" name="dataEdit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>340</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Enter JSON string that will be associated with the name</string>
+              </property>
+              <property name="maxLength">
+               <number>520000</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+         <widget class="QWidget" name="Hex">
+          <attribute name="title">
+           <string>Hex</string>
+          </attribute>
+          <widget class="QLabel" name="label_6">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>30</y>
+             <width>361</width>
+             <height>51</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Hex data is only recommended for power users&lt;br&gt;and developers.</string>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+          </widget>
+          <widget class="QWidget" name="layoutWidget_2">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>342</width>
+             <height>31</height>
+            </rect>
+           </property>
+           <layout class="QHBoxLayout" name="transferToLayout_4">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <item>
+             <widget class="QLineEdit" name="dataEditHex">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>340</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Enter JSON string that will be associated with the name</string>
+              </property>
+              <property name="maxLength">
+               <number>520000</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="3" column="1">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -97,61 +246,26 @@
        </property>
       </spacer>
      </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="labelTransferTo">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelNamespace">
        <property name="text">
-        <string>&amp;Transfer to:</string>
+        <string notr="true">TextLabel</string>
        </property>
        <property name="buddy">
-        <cstring>transferTo</cstring>
+        <cstring>dataEdit</cstring>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
-      <layout class="QHBoxLayout" name="transferToLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="sizeConstraint">
-        <enum>QLayout::SetDefaultConstraint</enum>
-       </property>
-       <item>
-        <widget class="QPayToEdit" name="transferTo">
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="8" column="1">
+     <item row="5" column="1">
       <widget class="QLabel" name="labelTransferToHint">
        <property name="text">
         <string>(Leave empty if not transferring.)</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="QLineEdit" name="dataEdit">
-         <property name="toolTip">
-          <string>Enter JSON string that will be associated with the name</string>
-         </property>
-         <property name="maxLength">
-          <number>520</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnDNSEditor">
-         <property name="text">
-          <string>DNS Editor&#8230;</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
     </layout>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QLabel" name="labelSubmitHint">
      <property name="text">
       <string notr="true">TextLabel</string>
@@ -167,7 +281,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <spacer name="horizontalSpacer">
@@ -209,8 +323,7 @@
    <header>qpaytoedit.h</header>
   </customwidget>
  </customwidgets>
- <resources>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
-> Making UI changes in the configure_name_dialog
-> Hanling non-ASCII encodings -> I chose not to pass the identifier in hexadecimal, as I did with value (DNS data), as it appeared redundant.
-> Rigging the two tabs
-> Currently, , exceptions are not being shown; should we showcase them in the `labelSubmitHint`?




